### PR TITLE
Use KST for logging and routing; prefer cash_balance for balance-split sizing

### DIFF
--- a/subscriber.py
+++ b/subscriber.py
@@ -9,12 +9,14 @@ import logging
 import os
 import signal
 import threading
+import datetime
 from concurrent.futures import TimeoutError
 from pathlib import Path
 
 from dotenv import load_dotenv
 
 from trading.dispatch import TradeDispatcher
+from trading.market_hours import KST
 from trading.schema import SignalValidationError, parse_signal_bytes
 
 
@@ -24,18 +26,32 @@ load_dotenv(ROOT / ".env")
 LOGGER = logging.getLogger("subscriber")
 
 
+class _KSTFormatter(logging.Formatter):
+    """Formatter that renders record times in Korea time, not server time."""
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:  # noqa: N802 - logging API
+        record_time = datetime.datetime.fromtimestamp(record.created, tz=KST)
+        if datefmt:
+            return record_time.strftime(datefmt)
+        return f"{record_time.strftime('%Y-%m-%d %H:%M:%S')},{int(record.msecs):03d}"
+
+
 def _configure_logging(log_file: str | None) -> None:
     handlers: list[logging.Handler] = [logging.StreamHandler()]
     if log_file:
         log_path = Path(log_file)
         log_path.parent.mkdir(parents=True, exist_ok=True)
         handlers.append(logging.FileHandler(log_path, encoding="utf-8"))
-    logging.basicConfig(
-        level=logging.INFO,
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-        handlers=handlers,
-        force=True,
-    )
+
+    formatter = _KSTFormatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    for handler in handlers:
+        handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.setLevel(logging.INFO)
+    for handler in handlers:
+        root_logger.addHandler(handler)
 
 
 class QueueWorker:

--- a/tests/test_balance_split_strategy.py
+++ b/tests/test_balance_split_strategy.py
@@ -90,7 +90,7 @@ async def test_balance_split_fails_without_available_balance():
 
 
 @pytest.mark.asyncio
-async def test_kr_balance_split_falls_back_to_deposit_when_orderable_cash_is_zero():
+async def test_kr_balance_split_falls_back_to_total_cash_when_orderable_cash_is_zero():
     trader = FakeKRTrader(available_amount=0, deposit=5795394, total_cash=5795394)
     strategy = BalanceSplitStrategy(config=BalanceSplitStrategyConfig(split_count=5))
     signal = parse_signal_payload({"type": "BUY", "ticker": "031330", "market": "KR", "price": 18860})
@@ -100,5 +100,35 @@ async def test_kr_balance_split_falls_back_to_deposit_when_orderable_cash_is_zer
     assert result.status == "executed"
     assert result.available_amount == 5795394
     assert result.buy_amount == 1159078.0
-    assert result.cash_source == "deposit"
+    assert result.cash_source == "cash_balance"
     assert trader.buy_calls == [("031330", 1159078, 18860)]
+
+
+@pytest.mark.asyncio
+async def test_kr_balance_split_uses_cash_balance_when_deposit_is_stale():
+    trader = FakeKRTrader(available_amount=0, deposit=29680834, total_cash=14824684)
+    strategy = BalanceSplitStrategy(config=BalanceSplitStrategyConfig(split_count=2))
+    signal = parse_signal_payload({"type": "BUY", "ticker": "443060", "market": "KR", "price": 226000})
+
+    result = await strategy._execute_kr(signal, trader=trader)
+
+    assert result.status == "executed"
+    assert result.available_amount == 14824684
+    assert result.buy_amount == 7412342.0
+    assert result.cash_source == "cash_balance"
+    assert trader.buy_calls == [("443060", 7412342, 226000)]
+
+
+@pytest.mark.asyncio
+async def test_balance_split_caps_orderable_cash_at_cash_balance_excluding_holdings():
+    trader = FakeKRTrader(available_amount=20000, deposit=30000, total_cash=12000)
+    strategy = BalanceSplitStrategy(config=BalanceSplitStrategyConfig(split_count=3))
+    signal = parse_signal_payload({"type": "BUY", "ticker": "005930", "market": "KR", "price": 80000})
+
+    result = await strategy._execute_kr(signal, trader=trader)
+
+    assert result.status == "executed"
+    assert result.available_amount == 12000
+    assert result.buy_amount == 4000.0
+    assert result.cash_source == "cash_balance"
+    assert trader.buy_calls == [("005930", 4000, 80000)]

--- a/tests/test_multi_account_domestic.py
+++ b/tests/test_multi_account_domestic.py
@@ -193,3 +193,35 @@ def test_smart_sell_routes_by_kst_not_server_local_time(monkeypatch):
 
     assert result["success"] is True
     assert calls == [("market", "080220")]
+
+
+def test_smart_buy_routes_after_kst_close_to_reserved_order(monkeypatch):
+    trader = dst.DomesticStockTrading.__new__(dst.DomesticStockTrading)
+    trader.auto_trading = True
+    calls = []
+
+    monkeypatch.setattr(dst, "_now_kst", lambda: dst.KST.localize(datetime(2026, 6, 8, 17, 23)))
+    trader.buy_market_price = lambda stock_code, buy_amount=None: calls.append(("market", stock_code, buy_amount)) or {"success": True}
+    trader.buy_closing_price = lambda stock_code, buy_amount=None: calls.append(("closing", stock_code, buy_amount)) or {"success": True}
+    trader.buy_reserved_order = lambda stock_code, buy_amount=None, limit_price=None: calls.append(("reserved", stock_code, buy_amount, limit_price)) or {"success": True}
+
+    result = trader.smart_buy("443060", buy_amount=100_000, limit_price=226_000)
+
+    assert result["success"] is True
+    assert calls == [("reserved", "443060", 100_000, 226_000)]
+
+
+def test_smart_sell_routes_after_kst_close_to_reserved_order(monkeypatch):
+    trader = dst.DomesticStockTrading.__new__(dst.DomesticStockTrading)
+    trader.auto_trading = True
+    calls = []
+
+    monkeypatch.setattr(dst, "_now_kst", lambda: dst.KST.localize(datetime(2026, 6, 8, 17, 23)))
+    trader.sell_all_market_price = lambda stock_code: calls.append(("market", stock_code)) or {"success": True}
+    trader.sell_all_closing_price = lambda stock_code: calls.append(("closing", stock_code)) or {"success": True}
+    trader.sell_all_reserved_order = lambda stock_code, limit_price=None: calls.append(("reserved", stock_code, limit_price)) or {"success": True}
+
+    result = trader.smart_sell_all("443060", limit_price=226_000)
+
+    assert result["success"] is True
+    assert calls == [("reserved", "443060", 226_000)]

--- a/trading/domestic.py
+++ b/trading/domestic.py
@@ -30,6 +30,15 @@ from .buy_sizing import build_buy_sizing, resolve_buy_amount
 from .market_hours import KST
 
 # Logging setup
+def _kst_log_time(*args: Any) -> time.struct_time:
+    """Render default logging timestamps in KST regardless of server TZ."""
+    timestamp = args[0] if args else None
+    if timestamp is None:
+        timestamp = time.time()
+    return datetime.datetime.fromtimestamp(timestamp, tz=KST).timetuple()
+
+
+logging.Formatter.converter = _kst_log_time
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
@@ -1153,7 +1162,7 @@ class DomesticStockTrading:
                 'total_amount': 0,
                 'order_no': None,
                 'message': f'Buy request timeout ({timeout}s)',
-                'timestamp': datetime.datetime.now().isoformat()
+                'timestamp': _now_kst().isoformat()
             }
 
     async def _execute_buy_stock(self, stock_code: str, buy_amount: int = None, limit_price: int = None) -> Dict[str, Any]:
@@ -1168,7 +1177,7 @@ class DomesticStockTrading:
             'total_amount': 0,
             'order_no': None,
             'message': '',
-            'timestamp': datetime.datetime.now().isoformat()
+            'timestamp': _now_kst().isoformat()
         }
 
         # 3-level protection: per-stock lock + semaphore + global lock
@@ -1275,7 +1284,7 @@ class DomesticStockTrading:
                 'estimated_amount': 0,
                 'order_no': None,
                 'message': f'Sell request timeout ({timeout}s)',
-                'timestamp': datetime.datetime.now().isoformat()
+                'timestamp': _now_kst().isoformat()
             }
 
     async def _execute_sell_stock(self, stock_code: str, limit_price: int = None) -> Dict[str, Any]:
@@ -1288,7 +1297,7 @@ class DomesticStockTrading:
             'estimated_amount': 0,
             'order_no': None,
             'message': '',
-            'timestamp': datetime.datetime.now().isoformat()
+            'timestamp': _now_kst().isoformat()
         }
 
         # 3-level protection: per-stock lock + semaphore + global lock
@@ -1529,7 +1538,8 @@ class DomesticStockTrading:
                         'total_profit_amount': float(output2.get('evlu_pfls_smtl_amt', 0)),
                         'total_profit_rate': round(float(output2.get('evlu_pfls_smtl_amt', 0)) / pchs_amt * 100, 2),
                         'deposit': dnca_tot_amt,  # Deposit (D+0, same-day withdrawal available)
-                        'total_cash': total_cash,  # Total cash (including D+2)
+                        'cash_balance': total_cash,  # Cash balance after excluding current stock holdings
+                        'total_cash': total_cash,  # Backward-compatible alias (including D+2)
                         'available_amount': float(output2.get('ord_psbl_cash', 0))
                     }
 
@@ -1537,7 +1547,7 @@ class DomesticStockTrading:
                                 f"profit/loss {account_summary['total_profit_amount']:+,.0f} KRW "
                                 f"({account_summary['total_profit_rate']:+.2f}%), "
                                 f"deposit {account_summary['deposit']:,.0f} KRW, "
-                                f"total cash(incl D+2) {account_summary['total_cash']:,.0f} KRW, "
+                                f"cash balance(excl holdings) {account_summary['cash_balance']:,.0f} KRW, "
                                 f"orderable cash {account_summary['available_amount']:,.0f} KRW")
 
                     return account_summary

--- a/trading/strategies/balance_split.py
+++ b/trading/strategies/balance_split.py
@@ -114,23 +114,43 @@ class BalanceSplitStrategy:
     def _available_amount(trader: _BuyTrader) -> tuple[float, str, dict[str, Any]]:
         summary = trader.get_account_summary() or {}
         available_amount = float(summary.get("available_amount", 0) or 0)
+        cash_balance = float(summary.get("cash_balance", summary.get("total_cash", 0)) or 0)
+
+        # For domestic accounts, cash_balance/total_cash is the cash portion of
+        # the account after excluding current stock holdings.  That is the
+        # intended balance_split base.  KIS can report ord_psbl_cash=0 outside
+        # regular hours, so use the cash balance in that case; when both values
+        # are positive, cap at the lower value so the strategy never overstates
+        # cash because of stale or more permissive broker fields.
+        if cash_balance > 0:
+            if available_amount > 0:
+                cash_amount = min(cash_balance, available_amount)
+                cash_source = "available_amount" if available_amount <= cash_balance else "cash_balance"
+            else:
+                cash_amount = cash_balance
+                cash_source = "cash_balance"
+            logger.info(
+                "Using %s %.2f as balance split cash base (cash_balance %.2f, available_amount %.2f)",
+                cash_source,
+                cash_amount,
+                cash_balance,
+                available_amount,
+            )
+            return cash_amount, cash_source, summary
+
         if available_amount > 0:
             return available_amount, "available_amount", summary
 
-        # KIS can report ord_psbl_cash=0 outside regular market hours while the
-        # cash/deposit balance is non-zero. Use cash as the sizing base so the
-        # broker gets the final say at order submission instead of failing before
-        # an order attempt with a misleading local no-balance error.
-        for key in ("deposit", "total_cash"):
-            cash_amount = float(summary.get(key, 0) or 0)
-            if cash_amount > 0:
-                logger.info(
-                    "Using %s %.2f as balance split cash base because available_amount is %.2f",
-                    key,
-                    cash_amount,
-                    available_amount,
-                )
-                return cash_amount, key, summary
+        # Last-resort compatibility fallback for account summaries that do not
+        # expose cash_balance/total_cash. Domestic KIS dnca_tot_amt (deposit) can
+        # remain stale after same-day buys, so it must not override cash_balance.
+        deposit = float(summary.get("deposit", 0) or 0)
+        if deposit > 0:
+            logger.info(
+                "Using deposit %.2f as balance split cash base because cash_balance and available_amount are zero",
+                deposit,
+            )
+            return deposit, "deposit", summary
 
         return 0.0, "available_amount", summary
 


### PR DESCRIPTION
### Motivation
- Ensure all logging timestamps and time-based routing use Korea Standard Time (`KST`) instead of the server local timezone to avoid misrouted orders and confusing logs. 
- Use the account cash amount that excludes current holdings as the primary base for balance-split buys so sizing is accurate even when `ord_psbl_cash` is zero outside market hours. 
- Avoid using stale `deposit` values as the primary sizing base and keep backward-compatible field names.

### Description
- Added a `_KSTFormatter` to `subscriber.py` and wired it into `_configure_logging` so console/file logs show `KST` timestamps and replaced the previous `basicConfig` setup. 
- In `trading/domestic.py` set `logging.Formatter.converter` to a `_kst_log_time` function and replaced return timestamps in buy/sell result structures with `_now_kst().isoformat()` so API responses use `KST`. 
- In `trading/domestic.py` changed account summary to include `cash_balance` (cash excluding holdings) and kept `total_cash` as an alias, and updated the account summary log message. 
- In `trading/strategies/balance_split.py` updated `_available_amount` to prefer `cash_balance` over `available_amount` when appropriate, cap the used amount to the lower of the two to avoid overstating cash, and fall back to `deposit` only as a last-resort compatibility behavior; added logging of chosen `cash_source`. 
- Updated and added unit tests in `tests/test_balance_split_strategy.py` and `tests/test_multi_account_domestic.py` to reflect the new `cash_balance` behavior and KST-based routing/reserved-order behavior after market close.

### Testing
- Ran the project unit tests with `pytest` focusing on `tests/test_balance_split_strategy.py` and `tests/test_multi_account_domestic.py`. 
- All modified and newly added tests executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a291385eda8832983d4ededa79ac16b)