### PR TITLE
Enhance logging (KST timestamps, daily rotation, log level) and improve message/worker logs

### DIFF
--- a/subscriber.py
+++ b/subscriber.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import datetime
 import logging
+import logging.handlers
 import os
 import signal
 import threading
-import datetime
 from concurrent.futures import TimeoutError
 from pathlib import Path
 
@@ -36,12 +37,63 @@ class _KSTFormatter(logging.Formatter):
         return f"{record_time.strftime('%Y-%m-%d %H:%M:%S')},{int(record.msecs):03d}"
 
 
-def _configure_logging(log_file: str | None) -> None:
+class _KSTDailyFileHandler(logging.handlers.BaseRotatingHandler):
+    """File handler that starts a fresh log file at each KST calendar day."""
+
+    def __init__(self, filename: Path, *, encoding: str = "utf-8"):
+        super().__init__(filename, mode="a", encoding=encoding, delay=False)
+        self.current_date = self._initial_log_date()
+
+    @staticmethod
+    def _date_from_timestamp(timestamp: float) -> datetime.date:
+        return datetime.datetime.fromtimestamp(timestamp, tz=KST).date()
+
+    def _initial_log_date(self) -> datetime.date:
+        log_path = Path(self.baseFilename)
+        if log_path.exists():
+            return self._date_from_timestamp(log_path.stat().st_mtime)
+        return datetime.datetime.now(tz=KST).date()
+
+    def shouldRollover(self, record: logging.LogRecord) -> bool:  # noqa: N802 - logging API
+        return self._date_from_timestamp(record.created) > self.current_date
+
+    def doRollover(self, new_date: datetime.date | None = None) -> None:  # noqa: N802 - logging API
+        if self.stream:
+            self.stream.close()
+            self.stream = None
+
+        rotated_name = f"{self.baseFilename}.{self.current_date.isoformat()}"
+        if os.path.exists(self.baseFilename):
+            if os.path.exists(rotated_name):
+                os.remove(rotated_name)
+            self.rotate(self.baseFilename, rotated_name)
+
+        self.current_date = new_date or datetime.datetime.now(tz=KST).date()
+        if not self.delay:
+            self.stream = self._open()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            if self.shouldRollover(record):
+                self.doRollover(self._date_from_timestamp(record.created))
+            logging.FileHandler.emit(self, record)
+        except Exception:
+            self.handleError(record)
+
+
+def _parse_log_level(level: str) -> int:
+    resolved = logging.getLevelName(level.upper())
+    if not isinstance(resolved, int):
+        raise ValueError(f"Unknown log level: {level}")
+    return resolved
+
+
+def _configure_logging(log_file: str | None, *, level: str = "INFO") -> None:
     handlers: list[logging.Handler] = [logging.StreamHandler()]
     if log_file:
         log_path = Path(log_file)
         log_path.parent.mkdir(parents=True, exist_ok=True)
-        handlers.append(logging.FileHandler(log_path, encoding="utf-8"))
+        handlers.append(_KSTDailyFileHandler(log_path, encoding="utf-8"))
 
     formatter = _KSTFormatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
     for handler in handlers:
@@ -49,7 +101,7 @@ def _configure_logging(log_file: str | None) -> None:
 
     root_logger = logging.getLogger()
     root_logger.handlers.clear()
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(_parse_log_level(level))
     for handler in handlers:
         root_logger.addHandler(handler)
 
@@ -62,15 +114,21 @@ class QueueWorker:
         self._thread: threading.Thread | None = None
 
     def start(self) -> None:
-        if self.dispatcher.dry_run or self.dispatcher.trading_mode != "demo":
+        if self.dispatcher.dry_run:
+            LOGGER.info("Queue worker disabled in dry-run mode")
+            return
+        if self.dispatcher.trading_mode != "demo":
+            LOGGER.info("Queue worker disabled outside demo mode (mode=%s)", self.dispatcher.trading_mode)
             return
         self._thread = threading.Thread(target=self._run, name="off-hours-queue", daemon=True)
         self._thread.start()
+        LOGGER.info("Queue worker started (poll_seconds=%s)", self.poll_seconds)
 
     def stop(self) -> None:
         self._stop_event.set()
         if self._thread:
             self._thread.join(timeout=2)
+            LOGGER.info("Queue worker stopped")
 
     def _run(self) -> None:
         while not self._stop_event.wait(self.poll_seconds):
@@ -82,25 +140,47 @@ class QueueWorker:
                 LOGGER.exception("Queue worker error: %s", exc)
 
 
+def _message_context(message) -> str:
+    parts = []
+    for attr in ("message_id", "publish_time", "ordering_key", "delivery_attempt"):
+        value = getattr(message, attr, None)
+        if value not in (None, ""):
+            parts.append(f"{attr}={value}")
+    return " ".join(parts) if parts else "message_id=unknown"
+
+
 def _handle_message(message, dispatcher: TradeDispatcher, logger: logging.Logger | None = None) -> None:
     active_logger = logger or LOGGER
+    context = _message_context(message)
+    active_logger.info("Received Pub/Sub message (%s, bytes=%s)", context, len(message.data or b""))
     try:
         signal = parse_signal_bytes(message.data)
+        active_logger.info(
+            "Dispatching %s %s(%s) market=%s price=%s (%s)",
+            signal.signal_type,
+            signal.company_name,
+            signal.ticker,
+            signal.market,
+            signal.price,
+            context,
+        )
         result = asyncio.run(dispatcher.dispatch(signal))
         active_logger.info(
-            "Handled %s %s(%s) -> %s: %s",
+            "Handled %s %s(%s) -> %s: %s (%s)",
             signal.signal_type,
             signal.company_name,
             signal.ticker,
             result.status,
             result.message,
+            context,
         )
     except SignalValidationError as exc:
-        active_logger.warning("Acknowledging invalid signal: %s", exc)
+        active_logger.warning("Acknowledging invalid signal (%s): %s", context, exc)
     except Exception as exc:  # noqa: BLE001 - safe ack avoids duplicate trading
-        active_logger.exception("Acknowledging processing failure: %s", exc)
+        active_logger.exception("Acknowledging processing failure (%s): %s", context, exc)
     finally:
         message.ack()
+        active_logger.info("Acknowledged Pub/Sub message (%s)", context)
 
 
 def build_callback(dispatcher: TradeDispatcher, logger: logging.Logger | None = None):
@@ -113,6 +193,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--subscription-id", default=os.environ.get("GCP_PUBSUB_SUBSCRIPTION_ID"))
     parser.add_argument("--credentials-path", default=os.environ.get("GCP_CREDENTIALS_PATH"))
     parser.add_argument("--log-file", default="logs/subscriber.log")
+    parser.add_argument(
+        "--log-level",
+        default=os.environ.get("LOG_LEVEL", "INFO"),
+        help="Python logging level (default: INFO)",
+    )
     parser.add_argument("--dry-run", action="store_true")
     parser.add_argument("--queue-path", default="runtime/off_hours_queue.json")
     parser.add_argument("--queue-poll-seconds", type=int, default=60)
@@ -139,7 +224,10 @@ def _start_web_ui_thread() -> threading.Thread:
 
 def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
-    _configure_logging(args.log_file)
+    try:
+        _configure_logging(args.log_file, level=args.log_level)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
 
     if not args.project_id or not args.subscription_id:
         raise SystemExit("GCP_PROJECT_ID and GCP_PUBSUB_SUBSCRIPTION_ID are required")
@@ -169,7 +257,14 @@ def main(argv: list[str] | None = None) -> None:
 
     subscriber = pubsub_v1.SubscriberClient(credentials=credentials) if credentials else pubsub_v1.SubscriberClient()
     subscription_path = subscriber.subscription_path(args.project_id, args.subscription_id)
-    LOGGER.info("Listening on %s (dry_run=%s, mode=%s)", subscription_path, args.dry_run, dispatcher.trading_mode)
+    LOGGER.info(
+        "Listening on %s (dry_run=%s, mode=%s, queue_path=%s, queue_poll_seconds=%s)",
+        subscription_path,
+        args.dry_run,
+        dispatcher.trading_mode,
+        args.queue_path,
+        args.queue_poll_seconds,
+    )
 
     streaming_pull_future = subscriber.subscribe(
         subscription_path,
@@ -214,6 +309,7 @@ def main(argv: list[str] | None = None) -> None:
             LOGGER.debug("Pub/Sub subscriber shutdown completed with %s", type(exc).__name__)
         queue_worker.stop()
         subscriber.close()
+        LOGGER.info("Subscriber shutdown complete")
 
 
 if __name__ == "__main__":

--- a/tests/test_subscriber_smoke.py
+++ b/tests/test_subscriber_smoke.py
@@ -169,9 +169,9 @@ def test_kst_daily_file_handler_rolls_over_on_kst_date(tmp_path):
     handler.setFormatter(logging.Formatter("%(message)s"))
 
     first_record = logging.LogRecord("test", logging.INFO, __file__, 1, "first", (), None)
-    first_record.created = datetime.datetime(2026, 6, 16, 23, 59, tzinfo=subscriber.KST).timestamp()
+    first_record.created = subscriber.KST.localize(datetime.datetime(2026, 6, 16, 23, 59)).timestamp()
     second_record = logging.LogRecord("test", logging.INFO, __file__, 1, "second", (), None)
-    second_record.created = datetime.datetime(2026, 6, 17, 0, 0, tzinfo=subscriber.KST).timestamp()
+    second_record.created = subscriber.KST.localize(datetime.datetime(2026, 6, 17, 0, 0)).timestamp()
 
     try:
         handler.emit(first_record)

--- a/tests/test_subscriber_smoke.py
+++ b/tests/test_subscriber_smoke.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import signal
 from concurrent.futures import TimeoutError
@@ -6,8 +7,10 @@ import subscriber
 
 
 class FakeMessage:
-    def __init__(self, data: bytes):
+    def __init__(self, data: bytes, message_id: str = "msg-1"):
         self.data = data
+        self.message_id = message_id
+        self.delivery_attempt = 2
         self.acked = False
 
     def ack(self):
@@ -48,7 +51,11 @@ def test_handle_message_logs_dispatch_message(caplog):
     with caplog.at_level(logging.INFO, logger="subscriber"):
         subscriber._handle_message(message, dispatcher, logger=subscriber.LOGGER)
 
+    assert "message_id=msg-1" in caplog.text
+    assert "delivery_attempt=2" in caplog.text
+    assert "Dispatching BUY" in caplog.text
     assert "-> executed: ok-message" in caplog.text
+    assert "Acknowledged Pub/Sub message" in caplog.text
 
 
 def test_web_ui_flag_still_requires_pubsub_settings(monkeypatch):
@@ -139,6 +146,41 @@ def test_web_ui_flag_runs_alongside_subscriber(monkeypatch):
 def test_parse_args_web_ui_flag():
     args = subscriber.parse_args(["--web-ui"])
     assert args.web_ui is True
+
+
+def test_parse_args_log_level_from_cli():
+    args = subscriber.parse_args(["--log-level", "DEBUG"])
+    assert args.log_level == "DEBUG"
+
+
+def test_configure_logging_rejects_unknown_level():
+    try:
+        subscriber._configure_logging(None, level="NOPE")
+    except ValueError as exc:
+        assert "Unknown log level" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("unknown log level should be rejected")
+
+
+def test_kst_daily_file_handler_rolls_over_on_kst_date(tmp_path):
+    log_path = tmp_path / "subscriber.log"
+    handler = subscriber._KSTDailyFileHandler(log_path)
+    handler.current_date = datetime.date(2026, 6, 16)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    first_record = logging.LogRecord("test", logging.INFO, __file__, 1, "first", (), None)
+    first_record.created = datetime.datetime(2026, 6, 16, 23, 59, tzinfo=subscriber.KST).timestamp()
+    second_record = logging.LogRecord("test", logging.INFO, __file__, 1, "second", (), None)
+    second_record.created = datetime.datetime(2026, 6, 17, 0, 0, tzinfo=subscriber.KST).timestamp()
+
+    try:
+        handler.emit(first_record)
+        handler.emit(second_record)
+    finally:
+        handler.close()
+
+    assert (tmp_path / "subscriber.log.2026-06-16").read_text(encoding="utf-8").strip() == "first"
+    assert log_path.read_text(encoding="utf-8").strip() == "second"
 
 
 def test_main_cancels_streaming_pull_on_sigint(monkeypatch):


### PR DESCRIPTION
### Motivation
- Make subscriber logs use Korea Standard Time for timestamps and rotate logs by KST calendar day to simplify day-based log management.
- Allow configurable Python logging level from CLI/ENV and reject unknown levels early.
- Surface richer Pub/Sub message context and lifecycle events in logs and make the off-hours queue worker behavior and lifecycle more visible.

### Description
- Add `_KSTFormatter` and `_KSTDailyFileHandler` to format times in `KST` and rotate log files on KST date boundaries, and replace the plain `FileHandler` with the new handler.
- Add `_parse_log_level` and a `--log-level` CLI argument, validate the level, and wire it into `_configure_logging`; unknown levels raise `ValueError` which is converted to `SystemExit` in `main`.
- Add `_message_context` and enrich `_handle_message` logs to include `message_id`, `publish_time`, `ordering_key`, and `delivery_attempt`, plus explicit ack/dispatch logs.
- Improve `QueueWorker` logging and behavior by explicitly disabling it in dry-run and non-demo modes with informative logs, and logging start/stop events.
- Add more startup/shutdown logging in `main` and include `queue_path` and `queue_poll_seconds` in the startup message.

### Testing
- Ran the updated unit tests in `tests/test_subscriber_smoke.py`, including `test_handle_message_logs_dispatch_message`, `test_parse_args_log_level_from_cli`, `test_configure_logging_rejects_unknown_level`, and `test_kst_daily_file_handler_rolls_over_on_kst_date`, and they passed.
- Existing smoke tests exercising `main` signal handling and WebUI interactions were executed and remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a315e781a2083298a680d6b98acde95)