### PR TITLE
Add trading/strategies/README.md with guide for creating new strategies

### DIFF
--- a/trading/strategies/README.md
+++ b/trading/strategies/README.md
@@ -1,0 +1,41 @@
+# Trading Strategies
+
+This package contains opt-in trading strategies that can replace the default
+signal execution path for specific signal types. Use the existing
+`balance_split` strategy as the reference implementation when adding another
+strategy.
+
+## How to add a new strategy
+
+1. **Create a strategy module** under `trading/strategies/` with a clear file
+   name, for example `my_strategy.py`.
+2. **Define a stable strategy name constant** in that module, such as
+   `MY_STRATEGY = "my_strategy"`. This value is what users put in
+   `signal_strategy.name` in `trading/config/kis_devlp.yaml`.
+3. **Add a config dataclass** with a `from_mapping()` class method. The method
+   should:
+   - Return `None` when the mapping is empty or when `name` does not match the
+     strategy constant.
+   - Validate strategy-specific options and raise `ValueError` for invalid
+     values.
+4. **Implement the strategy class** with an async `execute(signal, *,
+   trading_mode)` method. It should return a small execution result object with
+   at least `status` and `message` fields so the dispatcher can turn it into a
+   `DispatchResult`.
+5. **Keep market-specific broker calls inside the strategy** when the strategy
+   changes order sizing, price handling, reservations, or other execution
+   behavior. Use `USStockTrading` for US orders and `AsyncTradingContext` for KR
+   orders, following `balance_split.py`.
+6. **Export the new types** from `trading/strategies/__init__.py` so callers can
+   import them from `trading.strategies`.
+7. **Wire the strategy into `TradeDispatcher`** by loading the new config in
+   `trading/dispatch.py` and returning the strategy from `_resolve_buy_strategy()`
+   or a new resolver for the signal type it supports.
+8. **Document the user-facing config** in
+   `trading/config/kis_devlp.yaml.example`, including the strategy name and each
+   supported option.
+9. **Add tests** that cover config parsing, disabled or mismatched strategy
+   names, successful execution, rejection paths, and dispatcher routing.
+
+Strategies should be opt-in and should preserve the legacy execution path when
+`signal_strategy.name` is empty or names a different strategy.


### PR DESCRIPTION
### Motivation
- Provide an authored reference for authors who need to add opt-in trading strategies so new strategy implementations remain consistent and safe.
- Reduce risk of incorrect dispatcher wiring or config parsing by documenting the expected contracts and broker usage patterns.

### Description
- Add `trading/strategies/README.md` that describes how to add a new strategy module, choose a stable `name` constant, implement a config dataclass with `from_mapping()`, and implement an async `execute(signal, *, trading_mode)` contract.
- Document market-specific broker usage (use `USStockTrading` for US orders and `AsyncTradingContext` for KR orders), how to export types from `trading/strategies/__init__.py`, and how to wire the strategy into `TradeDispatcher` and the user config (`trading/config/kis_devlp.yaml.example`).
- Advise adding tests covering config parsing, disabled/mismatched strategy names, execution paths, and dispatcher routing.

### Testing
- Ran `python -m pytest tests/test_balance_split_strategy.py tests/test_dispatch.py`.
- All tests passed (`21 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3172b055188329a014bd3c76921840)