### PR TITLE
Enhance AI agent guidance and add read-only test-planner agent

### DIFF
--- a/.agents/skills/prism-insight-light/SKILL.md
+++ b/.agents/skills/prism-insight-light/SKILL.md
@@ -1,93 +1,69 @@
-```markdown
 # prism-insight-light Development Patterns
 
-> Auto-generated skill from repository analysis
+Repository-specific guidance for agents working on `prism-insight-light`, a Python trading-execution runtime for GCP Pub/Sub signals and Korea Investment & Securities (KIS) order routing.
 
-## Overview
-This skill teaches the core development patterns and conventions used in the `prism-insight-light` Python repository. It covers file organization, import/export styles, commit message habits, and testing patterns, providing practical examples and command suggestions for efficient contribution and maintenance.
+## Project Orientation
+
+- Keep the fork lightweight: preserve the runtime focus on Pub/Sub ingestion, signal validation, KIS Korean/US order execution, market-hours checks, off-hours queueing, Docker helpers, and the small web UI.
+- Do not reintroduce removed upstream scope such as analysis pipelines, broad reporting/orchestration, dashboards beyond the existing lightweight web UI, Firebase, Redis, or mobile integrations.
+- Treat trading behavior as high impact. Prefer `demo` mode, `--dry-run`, fixtures, and mocks before any real account path.
+- Never commit real credentials, KIS keys, account numbers, GCP service-account JSON, local `.env`, or live `trading/config/kis_devlp.yaml` values.
+
+## Repository Map
+
+| Path | Purpose |
+| --- | --- |
+| `subscriber.py` | Pub/Sub subscriber entrypoint and signal dispatch loop. |
+| `trading/` | Core trading runtime: auth, market-hours logic, schema validation, sizing, domestic/US orders, queueing, Telegram fetch. |
+| `trading/config/kis_devlp.yaml.example` | Safe example KIS configuration; keep live config out of git. |
+| `webui/` | Lightweight Flask-style web UI, routes, services, templates, and static assets. |
+| `tests/` | Regression tests for trading runtime, Docker helpers, readiness checks, and web UI behavior. |
+| `check_pubsub_readiness.py`, `pubsub_readiness.py` | Pub/Sub/GCP readiness checks. |
+| `install_prism_docker.sh`, `setup_subscriber*_crontab.sh` | Docker and cron helper scripts. |
 
 ## Coding Conventions
 
-### File Naming
-- Use **snake_case** for all file names.
-  - Example:  
-    ```plaintext
-    data_loader.py
-    utils/helpers.py
-    ```
+- Python files use `snake_case`; classes use `PascalCase`; constants use `SCREAMING_SNAKE_CASE`; functions should follow the existing surrounding module style.
+- Prefer small, dependency-light modules that can be tested with mocked KIS/GCP boundaries.
+- Keep imports explicit and local to the package where practical; avoid broad wildcard exports.
+- Never wrap imports in `try`/`except`; handle optional runtime behavior at call sites instead.
+- Keep user-facing README examples safe-by-default (`demo`, `--dry-run`, placeholder credentials).
+- Preserve Korean/US market distinctions and account-specific behavior when touching order routing.
 
-### Import Style
-- Use **relative imports** within the package.
-  - Example:
-    ```python
-    from .utils import data_parser
-    from ..core import engine
-    ```
+## Testing Workflow
 
-### Export Style
-- Use **named exports** (i.e., explicitly define what is exported from modules).
-  - Example:
-    ```python
-    __all__ = ['DataLoader', 'parse_data']
-    ```
+Before committing code changes, run the narrow relevant tests plus the full suite when feasible:
 
-### Commit Messages
-- Freeform style, no strict prefixing.
-- Average commit message length: ~41 characters.
-  - Example:
-    ```
-    Fix bug in data parsing for edge cases
-    ```
-
-## Workflows
-
-### Adding a New Module
-**Trigger:** When you need to introduce new functionality.
-**Command:** `/add-module`
-
-1. Create a new file using snake_case (e.g., `my_feature.py`).
-2. Implement your module, using relative imports for dependencies.
-3. Define `__all__` for named exports.
-4. Write corresponding test in a file matching `*.test.*` (e.g., `my_feature.test.py`).
-5. Commit with a clear, concise message.
-
-### Writing Tests
-**Trigger:** When adding or updating code that requires validation.
-**Command:** `/write-test`
-
-1. Create a test file with the pattern `*.test.*` (e.g., `utils.test.py`).
-2. Implement test cases for your functions/classes.
-3. Use the unknown (custom or standard) testing framework as appropriate.
-4. Run tests to ensure correctness.
-
-### Refactoring Imports
-**Trigger:** When reorganizing or cleaning up code dependencies.
-**Command:** `/refactor-imports`
-
-1. Replace absolute imports with relative imports within the package.
-2. Ensure all import paths are correct and modules are discoverable.
-3. Run tests to verify nothing is broken.
-
-## Testing Patterns
-
-- Test files follow the pattern `*.test.*` (e.g., `module.test.py`).
-- The specific testing framework is not detected; use standard Python testing practices (e.g., `unittest`, `pytest`, or custom).
-- Place tests alongside or near the modules they test.
-- Example test file:
-  ```python
-  # utils.test.py
-  import unittest
-  from .utils import parse_data
-
-  class TestParseData(unittest.TestCase):
-      def test_basic(self):
-          self.assertEqual(parse_data("1,2,3"), [1, 2, 3])
-  ```
-
-## Commands
-| Command           | Purpose                                         |
-|-------------------|------------------------------------------------|
-| /add-module       | Scaffold and add a new module with tests       |
-| /write-test       | Create or update test files for your code      |
-| /refactor-imports | Refactor code to use relative imports          |
+```bash
+python -m pytest
 ```
+
+For targeted work, prefer focused commands such as:
+
+```bash
+python -m pytest tests/test_schema.py tests/test_dispatch.py
+python -m pytest tests/test_webui_routes.py tests/test_webui_security.py
+python -m pytest tests/test_market_hours.py tests/test_off_hours_policy.py
+```
+
+When changing shell installers, run their smoke tests:
+
+```bash
+python -m pytest tests/test_docker_installer_smoke.py
+```
+
+## Change Checklist
+
+1. Identify the runtime boundary being changed: Pub/Sub, schema, KIS auth, domestic order, US order, sizing, queueing, web UI, Docker, or docs.
+2. Add or update tests under `tests/` that mirror the affected module or behavior.
+3. Use fixtures/mocks instead of network calls for KIS, GCP Pub/Sub, Telegram, or browser-dependent behavior.
+4. Validate default behavior remains safe for `demo` and `--dry-run`.
+5. Check docs/examples for credential leakage and safe defaults.
+6. Commit with a concise, imperative message.
+
+## Agent Collaboration
+
+- Use read-only explorer agents for tracing unfamiliar execution paths before editing.
+- Use reviewer agents for correctness, security, trading-safety, and regression review before finalizing.
+- Use docs research agents only when validating current external APIs or release-note claims against primary sources.
+- Share exact file paths, symbols, and test commands in handoffs so another agent can reproduce the reasoning.

--- a/.agents/skills/prism-insight-light/agents/openai.yaml
+++ b/.agents/skills/prism-insight-light/agents/openai.yaml
@@ -1,6 +1,9 @@
 interface:
   display_name: "Prism Insight Light"
-  short_description: "Repo-specific patterns and workflows for prism-insight-light"
-  default_prompt: "Use the prism-insight-light repo skill to follow existing architecture, testing, and workflow conventions."
+  short_description: "Safe, repo-specific guidance for the prism-insight-light trading runtime."
+  default_prompt: "Use the prism-insight-light repo skill to keep changes lightweight, tested, credential-safe, and aligned with the existing trading runtime architecture."
 policy:
   allow_implicit_invocation: true
+  safety_notes:
+    - "Default to demo and dry-run examples for trading workflows."
+    - "Do not store real credentials, account numbers, or service-account JSON in the repository."

--- a/.claude/ecc-tools.json
+++ b/.claude/ecc-tools.json
@@ -2,7 +2,7 @@
   "version": "1.3",
   "schemaVersion": "1.0",
   "generatedBy": "ecc-tools",
-  "generatedAt": "2026-06-10T09:25:40.517Z",
+  "generatedAt": "2026-06-16T00:00:00.000Z",
   "repo": "https://github.com/tkgo11/prism-insight-light",
   "referenceSetReadiness": {
     "score": 0,
@@ -153,7 +153,8 @@
     ".codex/agents/explorer.toml",
     ".codex/agents/reviewer.toml",
     ".codex/agents/docs-researcher.toml",
-    ".claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml"
+    ".claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml",
+    ".codex/agents/test-planner.toml"
   ],
   "packageFiles": {
     "runtime-core": [
@@ -166,7 +167,8 @@
       ".codex/agents/explorer.toml",
       ".codex/agents/reviewer.toml",
       ".codex/agents/docs-researcher.toml",
-      ".claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml"
+      ".claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml",
+      ".codex/agents/test-planner.toml"
     ]
   },
   "moduleFiles": {
@@ -180,7 +182,8 @@
       ".codex/agents/explorer.toml",
       ".codex/agents/reviewer.toml",
       ".codex/agents/docs-researcher.toml",
-      ".claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml"
+      ".claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml",
+      ".codex/agents/test-planner.toml"
     ]
   },
   "files": [
@@ -233,6 +236,11 @@
       "moduleId": "runtime-core",
       "path": ".claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml",
       "description": "Continuous-learning instincts derived from repository patterns."
+    },
+    {
+      "moduleId": "runtime-core",
+      "path": ".codex/agents/test-planner.toml",
+      "description": "Read-only test planning role config for Codex multi-agent validation."
     }
   ],
   "workflows": [],

--- a/.claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml
+++ b/.claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml
@@ -1,261 +1,102 @@
-# Instincts generated from https://github.com/tkgo11/prism-insight-light
-# Generated: 2026-06-10T09:25:58.242Z
-# Version: 2.0
+# Instincts generated and refined for https://github.com/tkgo11/prism-insight-light
+# Updated: 2026-06-16T00:00:00.000Z
+# Version: 2.1
 # NOTE: This file supplements (does not replace) any existing curated instincts.
-# High-confidence manually curated instincts should be preserved alongside these.
 
 ---
-id: prism-insight-light-commit-length
-trigger: "when writing a commit message"
-confidence: 0.6
-domain: git
-source: repo-analysis
-source_repo: https://github.com/tkgo11/prism-insight-light
----
-
-# Prism Insight Light Commit Length
-
-## Action
-
-Keep commit messages concise (~41 characters)
-
-## Evidence
-
-- Average commit message length: 41 chars
-- Based on 1 commits
-
----
-id: prism-insight-light-naming-files
-trigger: "when creating a new file"
-confidence: 0.8
-domain: code-style
-source: repo-analysis
-source_repo: https://github.com/tkgo11/prism-insight-light
----
-
-# Prism Insight Light Naming Files
-
-## Action
-
-Use snake_case naming convention
-
-## Evidence
-
-- Analyzed file naming patterns in repository
-- Dominant pattern: snake_case
-
----
-id: prism-insight-light-import-relative
-trigger: "when importing modules"
-confidence: 0.75
-domain: code-style
-source: repo-analysis
-source_repo: https://github.com/tkgo11/prism-insight-light
----
-
-# Prism Insight Light Import Relative
-
-## Action
-
-Use relative imports for project files
-
-## Evidence
-
-- Import analysis shows relative import pattern
-- Example: import { x } from '../lib/x'
-
----
-id: prism-insight-light-export-style
-trigger: "when exporting from a module"
-confidence: 0.7
-domain: code-style
-source: repo-analysis
-source_repo: https://github.com/tkgo11/prism-insight-light
----
-
-# Prism Insight Light Export Style
-
-## Action
-
-Prefer named exports
-
-## Evidence
-
-- Export pattern analysis
-- Dominant style: named
-
----
-id: prism-insight-light-test-separate
-trigger: "when writing tests"
-confidence: 0.8
-domain: testing
-source: repo-analysis
-source_repo: https://github.com/tkgo11/prism-insight-light
----
-
-# Prism Insight Light Test Separate
-
-## Action
-
-Place tests in the tests/ or __tests__/ directory, mirroring src structure
-
-## Evidence
-
-- Separate test directory pattern detected
-- Tests live in dedicated test folders
-
----
-id: prism-insight-light-instinct-file-naming
-trigger: "When creating a new Python file"
+id: prism-insight-light-runtime-scope
+trigger: "when planning a feature or refactor"
 confidence: 0.9
-domain: code-style
+domain: architecture
 source: repo-analysis
-source_repo: tkgo11/prism-insight-light
+source_repo: https://github.com/tkgo11/prism-insight-light
 ---
 
-# Prism Insight Light Instinct File Naming
+# Keep Runtime Scope Lightweight
 
 ## Action
 
-Name the file using snake_case
+Preserve the fork's focus on Pub/Sub signal ingestion, KIS order routing, market-hours checks, off-hours queueing, Docker helpers, and the lightweight web UI. Do not reintroduce removed analysis, reporting, Firebase, Redis, mobile, or broad orchestration scope.
 
 ## Evidence
 
-- Pattern in namingConventions.files
+- README describes the fork as a lightweight trading execution runtime.
+- Repository layout centers on `subscriber.py`, `trading/`, `webui/`, Docker helpers, and tests.
 
 ---
-id: prism-insight-light-instinct-function-naming
-trigger: "When defining a new function"
-confidence: 0.9
-domain: code-style
+id: prism-insight-light-trading-safety
+trigger: "when changing trading, sizing, auth, dispatch, or queue behavior"
+confidence: 0.95
+domain: safety
 source: repo-analysis
-source_repo: tkgo11/prism-insight-light
+source_repo: https://github.com/tkgo11/prism-insight-light
 ---
 
-# Prism Insight Light Instinct Function Naming
+# Prefer Safe Trading Defaults
 
 ## Action
 
-Name the function using camelCase
+Default examples and validation to `demo` mode, `--dry-run`, fixtures, and mocked KIS/GCP boundaries before any real account path.
 
 ## Evidence
 
-- Pattern in namingConventions.functions
+- README first-run flow recommends `default_mode: demo` and `--dry-run`.
+- Tests cover dispatch, sizing, market-hours, off-hours policy, schema, and web UI safety behavior.
 
 ---
-id: prism-insight-light-instinct-class-naming
-trigger: "When defining a new class"
-confidence: 0.9
-domain: code-style
+id: prism-insight-light-credential-hygiene
+trigger: "when editing configuration, documentation, installers, auth, or examples"
+confidence: 0.95
+domain: security
 source: repo-analysis
-source_repo: tkgo11/prism-insight-light
+source_repo: https://github.com/tkgo11/prism-insight-light
 ---
 
-# Prism Insight Light Instinct Class Naming
+# Protect Credentials
 
 ## Action
 
-Name the class using PascalCase
+Never commit real KIS keys, account numbers, GCP service-account JSON, `.env`, or live `trading/config/kis_devlp.yaml` content. Use placeholders and example files only.
 
 ## Evidence
 
-- Pattern in namingConventions.classes
+- README and `.env.example` use placeholders.
+- KIS live config is represented by `trading/config/kis_devlp.yaml.example`.
 
 ---
-id: prism-insight-light-instinct-constant-naming
-trigger: "When defining a constant"
-confidence: 0.9
+id: prism-insight-light-python-style
+trigger: "when creating or modifying Python modules"
+confidence: 0.85
 domain: code-style
 source: repo-analysis
-source_repo: tkgo11/prism-insight-light
+source_repo: https://github.com/tkgo11/prism-insight-light
 ---
 
-# Prism Insight Light Instinct Constant Naming
+# Match Python Style
 
 ## Action
 
-Name the constant using SCREAMING_SNAKE_CASE
+Use `snake_case` file names, `PascalCase` classes, `SCREAMING_SNAKE_CASE` constants, explicit imports, and dependency-light modules. Follow surrounding function naming style and never wrap imports in try/except blocks.
 
 ## Evidence
 
-- Pattern in namingConventions.constants
+- Existing modules under `trading/`, `webui/`, and `tests/` follow Python naming conventions.
 
 ---
-id: prism-insight-light-instinct-import-style
-trigger: "When importing modules within the package"
-confidence: 0.8
-domain: code-style
-source: repo-analysis
-source_repo: tkgo11/prism-insight-light
----
-
-# Prism Insight Light Instinct Import Style
-
-## Action
-
-Use relative imports
-
-## Evidence
-
-- Pattern in importStyle
-
----
-id: prism-insight-light-instinct-export-style
-trigger: "When exporting functions or classes"
-confidence: 0.8
-domain: code-style
-source: repo-analysis
-source_repo: tkgo11/prism-insight-light
----
-
-# Prism Insight Light Instinct Export Style
-
-## Action
-
-Use named exports
-
-## Evidence
-
-- Pattern in exportStyle
-
----
-id: prism-insight-light-instinct-test-location
-trigger: "When adding or updating tests"
+id: prism-insight-light-test-mirroring
+trigger: "when adding or changing behavior"
 confidence: 0.9
 domain: testing
 source: repo-analysis
-source_repo: tkgo11/prism-insight-light
+source_repo: https://github.com/tkgo11/prism-insight-light
 ---
 
-# Prism Insight Light Instinct Test Location
+# Mirror Behavior in Tests
 
 ## Action
 
-Place test files in the separate 'tests' folder
+Add or update tests under `tests/` that mirror affected runtime behavior. Use targeted pytest commands first, then the full suite when feasible.
 
 ## Evidence
 
-- Pattern in folderStructure.testLocation
-- Common folder: tests
-
----
-id: prism-insight-light-instinct-commit-format
-trigger: "When writing a git commit message"
-confidence: 0.8
-domain: git
-source: repo-analysis
-source_repo: tkgo11/prism-insight-light
----
-
-# Prism Insight Light Instinct Commit Format
-
-## Action
-
-Write a short, freeform message without prefixes, averaging around 40 characters
-
-## Evidence
-
-- Pattern in commits.type
-- Example: 'Use cash balance for balance split sizing'
-- commits.averageLength
-
+- The repository has dedicated tests for buy sizing, dispatch, market hours, multi-account behavior, readiness, schema, subscriber smoke, Telegram fetch, and web UI services/routes.

--- a/.claude/identity.json
+++ b/.claude/identity.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0",
+  "version": "2.1",
   "technicalLevel": "technical",
   "preferredStyle": {
     "verbosity": "detailed",
@@ -7,8 +7,19 @@
     "explanations": true
   },
   "domains": [
-    "python"
+    "python",
+    "automated-trading",
+    "gcp-pubsub",
+    "docker",
+    "web-ui"
   ],
   "suggestedBy": "ecc-tools-repo-analysis",
-  "createdAt": "2026-06-10T09:25:58.242Z"
+  "createdAt": "2026-06-10T09:25:58.242Z",
+  "operatingPrinciples": [
+    "Keep the fork focused on lightweight trading execution runtime scope.",
+    "Default examples and validation to demo mode and dry-run behavior.",
+    "Protect credentials and account identifiers from committed files.",
+    "Prefer tested, dependency-light changes with mocked external services."
+  ],
+  "updatedAt": "2026-06-16T00:00:00.000Z"
 }

--- a/.claude/skills/prism-insight-light/SKILL.md
+++ b/.claude/skills/prism-insight-light/SKILL.md
@@ -1,93 +1,69 @@
-```markdown
 # prism-insight-light Development Patterns
 
-> Auto-generated skill from repository analysis
+Repository-specific guidance for agents working on `prism-insight-light`, a Python trading-execution runtime for GCP Pub/Sub signals and Korea Investment & Securities (KIS) order routing.
 
-## Overview
-This skill teaches the core development patterns and conventions used in the `prism-insight-light` Python repository. It covers file organization, import/export styles, commit message habits, and testing patterns, providing practical examples and command suggestions for efficient contribution and maintenance.
+## Project Orientation
+
+- Keep the fork lightweight: preserve the runtime focus on Pub/Sub ingestion, signal validation, KIS Korean/US order execution, market-hours checks, off-hours queueing, Docker helpers, and the small web UI.
+- Do not reintroduce removed upstream scope such as analysis pipelines, broad reporting/orchestration, dashboards beyond the existing lightweight web UI, Firebase, Redis, or mobile integrations.
+- Treat trading behavior as high impact. Prefer `demo` mode, `--dry-run`, fixtures, and mocks before any real account path.
+- Never commit real credentials, KIS keys, account numbers, GCP service-account JSON, local `.env`, or live `trading/config/kis_devlp.yaml` values.
+
+## Repository Map
+
+| Path | Purpose |
+| --- | --- |
+| `subscriber.py` | Pub/Sub subscriber entrypoint and signal dispatch loop. |
+| `trading/` | Core trading runtime: auth, market-hours logic, schema validation, sizing, domestic/US orders, queueing, Telegram fetch. |
+| `trading/config/kis_devlp.yaml.example` | Safe example KIS configuration; keep live config out of git. |
+| `webui/` | Lightweight Flask-style web UI, routes, services, templates, and static assets. |
+| `tests/` | Regression tests for trading runtime, Docker helpers, readiness checks, and web UI behavior. |
+| `check_pubsub_readiness.py`, `pubsub_readiness.py` | Pub/Sub/GCP readiness checks. |
+| `install_prism_docker.sh`, `setup_subscriber*_crontab.sh` | Docker and cron helper scripts. |
 
 ## Coding Conventions
 
-### File Naming
-- Use **snake_case** for all file names.
-  - Example:  
-    ```plaintext
-    data_loader.py
-    utils/helpers.py
-    ```
+- Python files use `snake_case`; classes use `PascalCase`; constants use `SCREAMING_SNAKE_CASE`; functions should follow the existing surrounding module style.
+- Prefer small, dependency-light modules that can be tested with mocked KIS/GCP boundaries.
+- Keep imports explicit and local to the package where practical; avoid broad wildcard exports.
+- Never wrap imports in `try`/`except`; handle optional runtime behavior at call sites instead.
+- Keep user-facing README examples safe-by-default (`demo`, `--dry-run`, placeholder credentials).
+- Preserve Korean/US market distinctions and account-specific behavior when touching order routing.
 
-### Import Style
-- Use **relative imports** within the package.
-  - Example:
-    ```python
-    from .utils import data_parser
-    from ..core import engine
-    ```
+## Testing Workflow
 
-### Export Style
-- Use **named exports** (i.e., explicitly define what is exported from modules).
-  - Example:
-    ```python
-    __all__ = ['DataLoader', 'parse_data']
-    ```
+Before committing code changes, run the narrow relevant tests plus the full suite when feasible:
 
-### Commit Messages
-- Freeform style, no strict prefixing.
-- Average commit message length: ~41 characters.
-  - Example:
-    ```
-    Fix bug in data parsing for edge cases
-    ```
-
-## Workflows
-
-### Adding a New Module
-**Trigger:** When you need to introduce new functionality.
-**Command:** `/add-module`
-
-1. Create a new file using snake_case (e.g., `my_feature.py`).
-2. Implement your module, using relative imports for dependencies.
-3. Define `__all__` for named exports.
-4. Write corresponding test in a file matching `*.test.*` (e.g., `my_feature.test.py`).
-5. Commit with a clear, concise message.
-
-### Writing Tests
-**Trigger:** When adding or updating code that requires validation.
-**Command:** `/write-test`
-
-1. Create a test file with the pattern `*.test.*` (e.g., `utils.test.py`).
-2. Implement test cases for your functions/classes.
-3. Use the unknown (custom or standard) testing framework as appropriate.
-4. Run tests to ensure correctness.
-
-### Refactoring Imports
-**Trigger:** When reorganizing or cleaning up code dependencies.
-**Command:** `/refactor-imports`
-
-1. Replace absolute imports with relative imports within the package.
-2. Ensure all import paths are correct and modules are discoverable.
-3. Run tests to verify nothing is broken.
-
-## Testing Patterns
-
-- Test files follow the pattern `*.test.*` (e.g., `module.test.py`).
-- The specific testing framework is not detected; use standard Python testing practices (e.g., `unittest`, `pytest`, or custom).
-- Place tests alongside or near the modules they test.
-- Example test file:
-  ```python
-  # utils.test.py
-  import unittest
-  from .utils import parse_data
-
-  class TestParseData(unittest.TestCase):
-      def test_basic(self):
-          self.assertEqual(parse_data("1,2,3"), [1, 2, 3])
-  ```
-
-## Commands
-| Command           | Purpose                                         |
-|-------------------|------------------------------------------------|
-| /add-module       | Scaffold and add a new module with tests       |
-| /write-test       | Create or update test files for your code      |
-| /refactor-imports | Refactor code to use relative imports          |
+```bash
+python -m pytest
 ```
+
+For targeted work, prefer focused commands such as:
+
+```bash
+python -m pytest tests/test_schema.py tests/test_dispatch.py
+python -m pytest tests/test_webui_routes.py tests/test_webui_security.py
+python -m pytest tests/test_market_hours.py tests/test_off_hours_policy.py
+```
+
+When changing shell installers, run their smoke tests:
+
+```bash
+python -m pytest tests/test_docker_installer_smoke.py
+```
+
+## Change Checklist
+
+1. Identify the runtime boundary being changed: Pub/Sub, schema, KIS auth, domestic order, US order, sizing, queueing, web UI, Docker, or docs.
+2. Add or update tests under `tests/` that mirror the affected module or behavior.
+3. Use fixtures/mocks instead of network calls for KIS, GCP Pub/Sub, Telegram, or browser-dependent behavior.
+4. Validate default behavior remains safe for `demo` and `--dry-run`.
+5. Check docs/examples for credential leakage and safe defaults.
+6. Commit with a concise, imperative message.
+
+## Agent Collaboration
+
+- Use read-only explorer agents for tracing unfamiliar execution paths before editing.
+- Use reviewer agents for correctness, security, trading-safety, and regression review before finalizing.
+- Use docs research agents only when validating current external APIs or release-note claims against primary sources.
+- Share exact file paths, symbols, and test commands in handoffs so another agent can reproduce the reasoning.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,26 +1,35 @@
 # ECC for Codex CLI
 
-This supplements the root `AGENTS.md` with a repo-local ECC baseline.
+This supplements any root `AGENTS.md` with repo-local guidance for `prism-insight-light`.
 
-## Repo Skill
+## Repository Skill
 
-- Repo-generated Codex skill: `.agents/skills/prism-insight-light/SKILL.md`
+- Codex-facing skill: `.agents/skills/prism-insight-light/SKILL.md`
 - Claude-facing companion skill: `.claude/skills/prism-insight-light/SKILL.md`
-- Keep user-specific credentials and private MCPs in `~/.codex/config.toml`, not in this repo.
+- The skill is the canonical agent summary for architecture, safety defaults, testing, and collaboration patterns.
+
+## Safety Baseline
+
+- Keep this fork focused on trading execution runtime only; do not reintroduce removed analysis/reporting/orchestration scope.
+- Treat all trading paths as high impact. Prefer `demo`, `--dry-run`, mocks, and fixtures before real-account behavior.
+- Keep credentials out of git: no KIS secrets, account numbers, GCP service-account JSON, `.env`, or live `trading/config/kis_devlp.yaml`.
+- Keep user-specific credentials and private MCPs in `~/.codex/config.toml`, not in this repository.
 
 ## MCP Baseline
 
-Treat `.codex/config.toml` as the default ECC-safe baseline for work in this repository.
-The generated baseline enables GitHub, Context7, Exa, Memory, Playwright, and Sequential Thinking.
+Treat `.codex/config.toml` as the default ECC-safe baseline for work in this repository. The generated baseline enables GitHub, Context7, Exa, Memory, Playwright, and Sequential Thinking.
 
 ## Multi-Agent Support
 
-- Explorer: read-only evidence gathering
-- Reviewer: correctness, security, and regression review
-- Docs researcher: API and release-note verification
+- Explorer: read-only evidence gathering for unfamiliar execution paths.
+- Reviewer: correctness, security, trading-safety, and regression review.
+- Docs researcher: primary-source API and release-note verification.
+- Test planner: read-only test strategy and command selection for risky changes.
 
-## Workflow Files
+## Workflow Expectations
 
-- No dedicated workflow command files were generated for this repo.
-
-Use these workflow files as reusable task scaffolds when the detected repository workflows recur.
+1. Trace the affected path before editing.
+2. Make minimal, runtime-focused changes.
+3. Add or update tests for changed behavior.
+4. Run focused tests plus `python -m pytest` when feasible.
+5. Cite exact files, symbols, and test commands in final handoffs.

--- a/.codex/agents/docs-researcher.toml
+++ b/.codex/agents/docs-researcher.toml
@@ -4,6 +4,8 @@ sandbox_mode = "read-only"
 
 developer_instructions = """
 Verify APIs, framework behavior, and release-note claims against primary documentation before changes land.
-Cite the exact docs or file paths that support each claim.
-Do not invent undocumented behavior.
+Use primary sources for KIS/OpenAPI behavior, Google Cloud Pub/Sub behavior, Python packages, Docker, and browser tooling.
+Cite the exact docs or repository files that support each claim.
+Distinguish documented behavior from inference.
+Do not invent undocumented behavior or normalize credentials from examples into committed files.
 """

--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -4,6 +4,9 @@ sandbox_mode = "read-only"
 
 developer_instructions = """
 Stay in exploration mode.
-Trace the real execution path, cite files and symbols, and avoid proposing fixes unless the parent agent asks for them.
+Trace the real execution path through subscriber.py, trading/, webui/, scripts, and tests as applicable.
+Cite exact files, symbols, and line ranges that support each finding.
 Prefer targeted search and file reads over broad scans.
+Do not propose fixes unless the parent agent explicitly asks for options.
+Never inspect or print credential files such as .env, live KIS YAML, service-account JSON, or account secrets.
 """

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -3,7 +3,9 @@ model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 
 developer_instructions = """
-Review like an owner.
-Prioritize correctness, security, behavioral regressions, and missing tests.
-Lead with concrete findings and avoid style-only feedback unless it hides a real bug.
+Review like an owner of a trading runtime.
+Prioritize correctness, security, trading-safety, behavioral regressions, missing tests, and credential exposure.
+Check demo/dry-run defaults, market-hours behavior, account routing, KIS/GCP boundary mocks, and web UI guardrails when relevant.
+Lead with concrete findings that include file paths and reproducible impact.
+Avoid style-only feedback unless it hides a real bug or maintainability risk.
 """

--- a/.codex/agents/test-planner.toml
+++ b/.codex/agents/test-planner.toml
@@ -1,0 +1,10 @@
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+Design a practical validation plan for proposed changes without editing files.
+Map changed areas to existing tests under tests/ and identify the narrowest useful pytest commands.
+Call out when full `python -m pytest` is warranted because trading, auth, sizing, schema, or web UI guardrails are affected.
+Recommend mocks or fixtures for KIS, GCP Pub/Sub, Telegram, and browser-boundary behavior.
+"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -46,3 +46,7 @@ config_file = "agents/reviewer.toml"
 [agents.docs_researcher]
 description = "Documentation specialist that verifies APIs, framework behavior, and release notes."
 config_file = "agents/docs-researcher.toml"
+
+[agents.test_planner]
+description = "Read-only test strategy agent that maps changed areas to focused pytest commands."
+config_file = "agents/test-planner.toml"


### PR DESCRIPTION
### Motivation

- Provide clearer, repo-specific guidance for AI agents working on the lightweight trading runtime to protect credentials and keep changes focused and safe. 
- Emphasize testing and demo/dry-run defaults for any change touching trading, auth, sizing, dispatch, or web UI behavior. 
- Improve multi-agent roles so explorer/reviewer/docs-researcher agents produce actionable, reproducible findings and a dedicated read-only test-planner can map changes to focused pytest commands.

### Description

- Replace and enrich repository skills at `.agents/skills/prism-insight-light/SKILL.md` and `.claude/skills/prism-insight-light/SKILL.md` with project orientation, repository map, coding conventions, testing workflow, and a change checklist. 
- Strengthen OpenAI skill metadata at `.agents/skills/prism-insight-light/agents/openai.yaml` by updating the default prompt and adding explicit `safety_notes` to default to demo/dry-run examples and forbid committing real credentials. 
- Expand Codex guidance in `.codex/AGENTS.md` and `.codex/config.toml`, add a new `test-planner` role (`.codex/agents/test-planner.toml`), and refine `explorer`, `reviewer`, and `docs-researcher` `developer_instructions` for targeted, safety-first behavior. 
- Update Claude identity and instincts (`.claude/identity.json`, `.claude/homunculus/instincts/inherited/prism-insight-light-instincts.yaml`) and ECC metadata (`.claude/ecc-tools.json`) to emphasize lightweight runtime scope, credential hygiene, pytest validation, and to track the new test-planner config file.

### Testing

- `python - <<'PY' ... PY` was used to parse and validate updated JSON and TOML agent configuration files and succeeded. 
- Attempted to run the test suite with `python -m pytest`, but collection failed due to missing runtime dependencies in the environment (`python-dotenv`, `requests`, `fastapi`), producing 11 collection errors. 
- Tried installing requirements with `python -m pip install -r requirements.txt`, but dependency installation was aborted because building `pandas` from source on Python 3.14 would take too long in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31731fa7cc83298b449d159df09ebf)