### PR TITLE
Add opt-in trading strategies and wire into dispatcher

### DIFF
--- a/tests/test_strategy_suite.py
+++ b/tests/test_strategy_suite.py
@@ -13,11 +13,11 @@ from trading.strategies.event_risk_off import EventRiskOffStrategy, EventRiskOff
 
 class FakeUSTrader:
     calls = []
-    def __init__(self, mode): self.mode = mode
+    def __init__(self, mode, account_name=None, account_index=None): self.mode = mode; self.account_name = account_name; self.account_index = account_index
     async def async_buy_stock(self, ticker, buy_amount=None, limit_price=None):
         self.calls.append(("buy", ticker, buy_amount, limit_price)); return {"success": True, "message": "buy-ok"}
-    async def async_sell_stock(self, ticker, limit_price=None):
-        self.calls.append(("sell", ticker, None, limit_price)); return {"success": True, "message": "sell-ok"}
+    async def async_sell_stock(self, ticker, limit_price=None, sell_fraction=None):
+        self.calls.append(("sell", ticker, sell_fraction, limit_price)); return {"success": True, "message": "sell-ok"}
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_strategy_suite.py
+++ b/tests/test_strategy_suite.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+
+from trading.schema import parse_signal_payload
+from trading.strategies.limit_buffer import LimitBufferStrategy, LimitBufferStrategyConfig
+from trading.strategies.profit_ladder import ProfitLadderStrategyConfig
+from trading.strategies.risk_bracket import RiskBracketStrategy, RiskBracketStrategyConfig
+from trading.strategies.score_weighted import ScoreWeightedStrategy, ScoreWeightedStrategyConfig
+from trading.strategies.cooldown import CooldownStrategy, CooldownStrategyConfig
+from trading.strategies.event_risk_off import EventRiskOffStrategy, EventRiskOffStrategyConfig
+
+
+class FakeUSTrader:
+    calls = []
+    def __init__(self, mode): self.mode = mode
+    async def async_buy_stock(self, ticker, buy_amount=None, limit_price=None):
+        self.calls.append(("buy", ticker, buy_amount, limit_price)); return {"success": True, "message": "buy-ok"}
+    async def async_sell_stock(self, ticker, limit_price=None):
+        self.calls.append(("sell", ticker, None, limit_price)); return {"success": True, "message": "sell-ok"}
+
+
+@pytest.fixture(autouse=True)
+def fake_us(monkeypatch):
+    FakeUSTrader.calls = []
+    monkeypatch.setattr("trading.strategies.common.USStockTrading", FakeUSTrader)
+
+
+@pytest.mark.asyncio
+async def test_score_weighted_buys_from_score_band():
+    config = ScoreWeightedStrategyConfig.from_mapping({"name": "score_weighted", "base_amount_usd": 200, "score_bands": {70: .5, 90: 1}})
+    signal = parse_signal_payload({"type": "BUY", "ticker": "AAPL", "market": "US", "price": 10, "buy_score": 80})
+
+    result = await ScoreWeightedStrategy(config=config).execute(signal, trading_mode="demo")
+
+    assert result.status == "executed"
+    assert FakeUSTrader.calls == [("buy", "AAPL", 100.0, 10.0)]
+
+
+def test_profit_ladder_config_parses_bands_and_reasons():
+    config = ProfitLadderStrategyConfig.from_mapping({"name": "profit_ladder", "profit_bands": {"5": .25}, "full_exit_reasons": ["manual_exit"]})
+
+    assert config.profit_bands == {5.0: .25}
+    assert config.full_exit_reasons == ("manual_exit",)
+
+
+@pytest.mark.asyncio
+async def test_limit_buffer_adjusts_sell_price():
+    config = LimitBufferStrategyConfig.from_mapping({"name": "limit_buffer", "sell_buffer_percent": 1, "us_price_decimals": 2})
+    signal = parse_signal_payload({"type": "SELL", "ticker": "AAPL", "market": "US", "price": 100})
+
+    result = await LimitBufferStrategy(config=config).execute(signal, trading_mode="demo")
+
+    assert result.status == "executed"
+    assert FakeUSTrader.calls == [("sell", "AAPL", None, 99.0)]
+
+
+@pytest.mark.asyncio
+async def test_risk_bracket_rejects_stop_above_entry(tmp_path):
+    config = RiskBracketStrategyConfig.from_mapping({"name": "risk_bracket", "risk_amount_usd": 25})
+    strategy = RiskBracketStrategy(config=config)
+    strategy.metadata_path = tmp_path / "risk.json"
+    signal = parse_signal_payload({"type": "BUY", "ticker": "AAPL", "market": "US", "price": 100, "stop_loss": 101})
+
+    result = await strategy.execute(signal, trading_mode="demo")
+
+    assert result.status == "rejected"
+    assert FakeUSTrader.calls == []
+
+
+@pytest.mark.asyncio
+async def test_cooldown_blocks_duplicate_execution(tmp_path):
+    config = CooldownStrategyConfig.from_mapping({"name": "cooldown", "runtime_path": str(tmp_path / "cooldown.json")})
+    strategy = CooldownStrategy(config=config)
+    signal = parse_signal_payload({"type": "BUY", "ticker": "AAPL", "market": "US", "price": 100})
+
+    first = await strategy.execute(signal, trading_mode="demo")
+    second = await strategy.execute(signal, trading_mode="demo")
+
+    assert first.status == "executed"
+    assert second.status == "rejected"
+    assert len(FakeUSTrader.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_event_risk_off_records_event_and_blocks_buy(tmp_path):
+    config = EventRiskOffStrategyConfig.from_mapping({"name": "event_risk_off", "runtime_path": str(tmp_path / "risk_off.json")})
+    strategy = EventRiskOffStrategy(config=config)
+    event = parse_signal_payload({"type": "EVENT", "ticker": "AAPL", "market": "US", "event_type": "RISK_OFF", "price": 0})
+    buy = parse_signal_payload({"type": "BUY", "ticker": "AAPL", "market": "US", "price": 100})
+
+    event_result = await strategy.execute(event, trading_mode="demo")
+    buy_result = await strategy.execute(buy, trading_mode="demo")
+
+    assert event_result.status == "acknowledged"
+    assert buy_result.status == "rejected"
+    assert FakeUSTrader.calls == []

--- a/trading/config/kis_devlp.yaml.example
+++ b/trading/config/kis_devlp.yaml.example
@@ -117,9 +117,51 @@ accounts:
 # 신호 기반 전략 설정
 # - name: ""              기존 동작 유지 (전략 비활성화)
 # - name: "balance_split" BUY 신호마다 현재 주문 가능 잔고의 1/split_count만 매수
+# - name: "score_weighted" buy_score 구간별 비중으로 매수 금액 조정
+# - name: "risk_bracket" stop_loss/target_price 기반 리스크 예산 매수
+# - name: "profit_ladder" profit_rate/sell_reason 기반 단계적 SELL
+# - name: "limit_buffer" BUY/SELL 지정가에 완충 비율 적용
+# - name: "cooldown" 같은 종목/신호의 반복 주문 방지
+# - name: "event_risk_off" EVENT 신호로 임시 risk-off 상태 기록
 signal_strategy:
   name: ""
   split_count: 2
+  # score_weighted
+  base_amount_krw: 50000
+  base_amount_usd: 100
+  min_score: 60
+  score_bands:
+    60: 0.25
+    75: 0.5
+    90: 1.0
+  # risk_bracket
+  risk_amount_krw: 10000
+  risk_amount_usd: 25
+  max_position_amount_krw: 100000
+  max_position_amount_usd: 500
+  require_stop_loss: true
+  require_target_price: false
+  # profit_ladder
+  profit_bands:
+    5: 0.25
+    10: 0.5
+    20: 1.0
+  stop_loss_sell_percent: 1.0
+  default_sell_percent: 1.0
+  full_exit_reasons: ["stop_loss", "risk_off", "manual_exit"]
+  # limit_buffer
+  buy_buffer_percent: 0.1
+  sell_buffer_percent: 0.1
+  us_price_decimals: 2
+  kr_tick_rounding: 1
+  # cooldown
+  window_minutes: 60
+  apply_to_signal_types: ["BUY"]
+  scope: "market_ticker"
+  # event_risk_off
+  risk_off_event_types: ["RISK_OFF"]
+  risk_off_window_minutes: 1440
+  buy_size_multiplier: 0.0
 
 # User-Agent
 # 보통 기본값 그대로 사용해도 됩니다.

--- a/trading/config/kis_devlp.yaml.example
+++ b/trading/config/kis_devlp.yaml.example
@@ -148,7 +148,10 @@ signal_strategy:
     20: 1.0
   stop_loss_sell_percent: 1.0
   default_sell_percent: 1.0
-  full_exit_reasons: ["stop_loss", "risk_off", "manual_exit"]
+  full_exit_reasons:
+    - stop_loss
+    - risk_off
+    - manual_exit
   # limit_buffer
   buy_buffer_percent: 0.1
   sell_buffer_percent: 0.1
@@ -156,10 +159,12 @@ signal_strategy:
   kr_tick_rounding: 1
   # cooldown
   window_minutes: 60
-  apply_to_signal_types: ["BUY"]
+  apply_to_signal_types:
+    - BUY
   scope: "market_ticker"
   # event_risk_off
-  risk_off_event_types: ["RISK_OFF"]
+  risk_off_event_types:
+    - RISK_OFF
   risk_off_window_minutes: 1440
   buy_size_multiplier: 0.0
 

--- a/trading/dispatch.py
+++ b/trading/dispatch.py
@@ -14,7 +14,22 @@ from .domestic import AsyncTradingContext
 from .market_hours import get_trading_mode, is_market_open
 from .off_hours_queue import OffHoursOrderQueue
 from .schema import SignalMessage, parse_signal_payload
-from .strategies import BalanceSplitStrategy, BalanceSplitStrategyConfig
+from .strategies import (
+    BalanceSplitStrategy,
+    BalanceSplitStrategyConfig,
+    CooldownStrategy,
+    CooldownStrategyConfig,
+    EventRiskOffStrategy,
+    EventRiskOffStrategyConfig,
+    LimitBufferStrategy,
+    LimitBufferStrategyConfig,
+    ProfitLadderStrategy,
+    ProfitLadderStrategyConfig,
+    RiskBracketStrategy,
+    RiskBracketStrategyConfig,
+    ScoreWeightedStrategy,
+    ScoreWeightedStrategyConfig,
+)
 from .us import USStockTrading
 
 
@@ -50,11 +65,21 @@ class TradeDispatcher:
         self.queue = queue or OffHoursOrderQueue(queue_path)
         self.strategy_config = strategy_config if strategy_config is not None else self._load_strategy_config()
         self.balance_split_config = BalanceSplitStrategyConfig.from_mapping(self.strategy_config)
+        self.score_weighted_config = ScoreWeightedStrategyConfig.from_mapping(self.strategy_config)
+        self.risk_bracket_config = RiskBracketStrategyConfig.from_mapping(self.strategy_config)
+        self.profit_ladder_config = ProfitLadderStrategyConfig.from_mapping(self.strategy_config)
+        self.limit_buffer_config = LimitBufferStrategyConfig.from_mapping(self.strategy_config)
+        self.cooldown_config = CooldownStrategyConfig.from_mapping(self.strategy_config)
+        self.event_risk_off_config = EventRiskOffStrategyConfig.from_mapping(self.strategy_config)
         self.account_name = account_name
         self.account_index = account_index
 
     async def dispatch(self, signal: SignalMessage, *, allow_queue: bool = True) -> DispatchResult:
+        event_strategy = self._resolve_event_strategy(signal)
         if signal.is_event:
+            if event_strategy is not None:
+                strategy_result = await event_strategy.execute(signal, trading_mode=self.trading_mode)
+                return DispatchResult(strategy_result.status, strategy_result.message, signal.signal_type, signal.market)
             logger.info("Ignoring EVENT signal for %s(%s)", signal.company_name, signal.ticker)
             return DispatchResult("acknowledged", "Event signal acknowledged", signal.signal_type, signal.market)
 
@@ -62,7 +87,7 @@ class TradeDispatcher:
             logger.info("[DRY-RUN] %s %s(%s)", signal.signal_type, signal.company_name, signal.ticker)
             return DispatchResult("dry-run", "Dry-run mode; no trade executed", signal.signal_type, signal.market)
 
-        strategy = self._resolve_buy_strategy(signal)
+        strategy = self._resolve_strategy(signal)
 
         if not is_market_open(signal.market):
             if self.trading_mode == "demo" and allow_queue:
@@ -115,10 +140,32 @@ class TradeDispatcher:
             payload = yaml.safe_load(fh) or {}
         return payload.get("signal_strategy") or {}
 
+    def _resolve_event_strategy(self, signal: SignalMessage) -> EventRiskOffStrategy | None:
+        if signal.is_event and self.event_risk_off_config is not None:
+            return EventRiskOffStrategy(config=self.event_risk_off_config)
+        return None
+
+    def _resolve_strategy(self, signal: SignalMessage):
+        if self.event_risk_off_config is not None:
+            return EventRiskOffStrategy(config=self.event_risk_off_config)
+        if self.cooldown_config is not None:
+            return CooldownStrategy(config=self.cooldown_config)
+        if self.limit_buffer_config is not None and signal.is_trade:
+            return LimitBufferStrategy(config=self.limit_buffer_config)
+        if signal.signal_type == "BUY":
+            if self.balance_split_config is not None:
+                return BalanceSplitStrategy(config=self.balance_split_config)
+            if self.score_weighted_config is not None:
+                return ScoreWeightedStrategy(config=self.score_weighted_config)
+            if self.risk_bracket_config is not None:
+                return RiskBracketStrategy(config=self.risk_bracket_config)
+        if signal.signal_type == "SELL" and self.profit_ladder_config is not None:
+            return ProfitLadderStrategy(config=self.profit_ladder_config)
+        return None
+
     def _resolve_buy_strategy(self, signal: SignalMessage) -> BalanceSplitStrategy | None:
-        if signal.signal_type != "BUY" or self.balance_split_config is None:
-            return None
-        return BalanceSplitStrategy(config=self.balance_split_config)
+        strategy = self._resolve_strategy(signal)
+        return strategy if isinstance(strategy, BalanceSplitStrategy) else None
 
     def _trader_kwargs(self) -> dict[str, Any]:
         kwargs: dict[str, Any] = {"mode": self.trading_mode}

--- a/trading/dispatch.py
+++ b/trading/dispatch.py
@@ -75,17 +75,17 @@ class TradeDispatcher:
         self.account_index = account_index
 
     async def dispatch(self, signal: SignalMessage, *, allow_queue: bool = True) -> DispatchResult:
-        event_strategy = self._resolve_event_strategy(signal)
-        if signal.is_event:
-            if event_strategy is not None:
-                strategy_result = await event_strategy.execute(signal, trading_mode=self.trading_mode)
-                return DispatchResult(strategy_result.status, strategy_result.message, signal.signal_type, signal.market)
-            logger.info("Ignoring EVENT signal for %s(%s)", signal.company_name, signal.ticker)
-            return DispatchResult("acknowledged", "Event signal acknowledged", signal.signal_type, signal.market)
-
         if self.dry_run:
             logger.info("[DRY-RUN] %s %s(%s)", signal.signal_type, signal.company_name, signal.ticker)
             return DispatchResult("dry-run", "Dry-run mode; no trade executed", signal.signal_type, signal.market)
+
+        event_strategy = self._resolve_event_strategy(signal)
+        if signal.is_event:
+            if event_strategy is not None:
+                strategy_result = await event_strategy.execute(signal, trading_mode=self.trading_mode, trader_kwargs=self._strategy_trader_kwargs())
+                return DispatchResult(strategy_result.status, strategy_result.message, signal.signal_type, signal.market)
+            logger.info("Ignoring EVENT signal for %s(%s)", signal.company_name, signal.ticker)
+            return DispatchResult("acknowledged", "Event signal acknowledged", signal.signal_type, signal.market)
 
         strategy = self._resolve_strategy(signal)
 
@@ -119,7 +119,7 @@ class TradeDispatcher:
             return DispatchResult("rejected", "Market closed in real mode", signal.signal_type, signal.market)
 
         if strategy is not None:
-            strategy_result = await strategy.execute(signal, trading_mode=self.trading_mode)
+            strategy_result = await strategy.execute(signal, trading_mode=self.trading_mode, trader_kwargs=self._strategy_trader_kwargs())
             return DispatchResult(strategy_result.status, strategy_result.message, signal.signal_type, signal.market)
 
         return await self._execute_legacy_trade(signal)
@@ -167,13 +167,16 @@ class TradeDispatcher:
         strategy = self._resolve_strategy(signal)
         return strategy if isinstance(strategy, BalanceSplitStrategy) else None
 
-    def _trader_kwargs(self) -> dict[str, Any]:
-        kwargs: dict[str, Any] = {"mode": self.trading_mode}
+    def _strategy_trader_kwargs(self) -> dict[str, Any]:
+        kwargs: dict[str, Any] = {}
         if self.account_name:
             kwargs["account_name"] = self.account_name
         if self.account_index is not None:
             kwargs["account_index"] = self.account_index
         return kwargs
+
+    def _trader_kwargs(self) -> dict[str, Any]:
+        return {"mode": self.trading_mode, **self._strategy_trader_kwargs()}
 
     async def _execute_legacy_trade(self, signal: SignalMessage) -> DispatchResult:
         limit_price = None if signal.price in (None, 0) else signal.price

--- a/trading/strategies/README.md
+++ b/trading/strategies/README.md
@@ -5,6 +5,16 @@ signal execution path for specific signal types. Use the existing
 `balance_split` strategy as the reference implementation when adding another
 strategy.
 
+## Built-in strategies
+
+- `balance_split`: BUY with a fraction of currently available cash.
+- `score_weighted`: BUY with a configured amount multiplied by the incoming `buy_score` band.
+- `risk_bracket`: BUY from a risk budget derived from `price` and `stop_loss`, with optional bracket metadata persistence.
+- `profit_ladder`: SELL through configured `profit_rate` bands or full-exit reasons.
+- `limit_buffer`: BUY/SELL using a buffered limit price around the signal price.
+- `cooldown`: execute a trade only when the same configured ticker/signal key has not traded recently.
+- `event_risk_off`: record risk-off EVENT signals and reject matching BUY signals while the state is fresh.
+
 ## How to add a new strategy
 
 1. **Create a strategy module** under `trading/strategies/` with a clear file

--- a/trading/strategies/__init__.py
+++ b/trading/strategies/__init__.py
@@ -1,9 +1,33 @@
 """Strategy primitives for opt-in trading policies."""
 
 from .balance_split import BALANCE_SPLIT, BalanceSplitStrategy, BalanceSplitStrategyConfig
+from .cooldown import COOLDOWN, CooldownStrategy, CooldownStrategyConfig
+from .event_risk_off import EVENT_RISK_OFF, EventRiskOffStrategy, EventRiskOffStrategyConfig
+from .limit_buffer import LIMIT_BUFFER, LimitBufferStrategy, LimitBufferStrategyConfig
+from .profit_ladder import PROFIT_LADDER, ProfitLadderStrategy, ProfitLadderStrategyConfig
+from .risk_bracket import RISK_BRACKET, RiskBracketStrategy, RiskBracketStrategyConfig
+from .score_weighted import SCORE_WEIGHTED, ScoreWeightedStrategy, ScoreWeightedStrategyConfig
 
 __all__ = [
     "BALANCE_SPLIT",
     "BalanceSplitStrategy",
     "BalanceSplitStrategyConfig",
+    "COOLDOWN",
+    "CooldownStrategy",
+    "CooldownStrategyConfig",
+    "EVENT_RISK_OFF",
+    "EventRiskOffStrategy",
+    "EventRiskOffStrategyConfig",
+    "LIMIT_BUFFER",
+    "LimitBufferStrategy",
+    "LimitBufferStrategyConfig",
+    "PROFIT_LADDER",
+    "ProfitLadderStrategy",
+    "ProfitLadderStrategyConfig",
+    "RISK_BRACKET",
+    "RiskBracketStrategy",
+    "RiskBracketStrategyConfig",
+    "SCORE_WEIGHTED",
+    "ScoreWeightedStrategy",
+    "ScoreWeightedStrategyConfig",
 ]

--- a/trading/strategies/balance_split.py
+++ b/trading/strategies/balance_split.py
@@ -64,7 +64,7 @@ class BalanceSplitStrategy:
         self.config = config
         self.reservation_path = RESERVATION_PATH
 
-    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> BalanceSplitExecution:
+    async def execute(self, signal: SignalMessage, *, trading_mode: str, trader_kwargs: dict[str, Any] | None = None) -> BalanceSplitExecution:
         if signal.signal_type != "BUY":
             return BalanceSplitExecution(
                 status="rejected",
@@ -77,10 +77,10 @@ class BalanceSplitStrategy:
             )
 
         if signal.market == "US":
-            trader = USStockTrading(mode=trading_mode)
+            trader = USStockTrading(mode=trading_mode, **(trader_kwargs or {}))
             return await self._execute_us(signal, trader=trader)
 
-        async with AsyncTradingContext(mode=trading_mode) as trader:
+        async with AsyncTradingContext(mode=trading_mode, **(trader_kwargs or {})) as trader:
             return await self._execute_kr(signal, trader=trader)
 
     async def _execute_us(self, signal: SignalMessage, *, trader: _BuyTrader) -> BalanceSplitExecution:

--- a/trading/strategies/common.py
+++ b/trading/strategies/common.py
@@ -1,0 +1,123 @@
+"""Shared helpers for opt-in trading strategies."""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+from ..domestic import AsyncTradingContext
+from ..schema import SignalMessage
+from ..us import USStockTrading
+
+logger = logging.getLogger(__name__)
+RUNTIME_DIR = Path(__file__).resolve().parents[2] / "runtime"
+
+
+@dataclass(slots=True)
+class StrategyExecution:
+    status: str
+    message: str
+    market: str
+    ticker: str = ""
+    details: dict[str, Any] | None = None
+
+
+class StrategyTrader(Protocol):
+    def get_account_summary(self) -> dict[str, Any] | None: ...
+
+
+def strategy_name(payload: dict[str, Any] | None) -> str:
+    return str((payload or {}).get("name", "")).strip()
+
+
+def number(payload: dict[str, Any], key: str, default: float = 0.0) -> float:
+    value = payload.get(key, default)
+    if value in (None, ""):
+        return default
+    return float(value)
+
+
+def positive_number(payload: dict[str, Any], key: str, default: float = 0.0) -> float:
+    value = number(payload, key, default)
+    if value < 0:
+        raise ValueError(f"signal_strategy.{key} must be 0 or greater")
+    return value
+
+
+def market_base_amount(signal: SignalMessage, *, krw: float, usd: float) -> float:
+    return usd if signal.market == "US" else krw
+
+
+def available_cash(trader: StrategyTrader) -> float:
+    summary = trader.get_account_summary() or {}
+    return float(summary.get("available_amount", summary.get("cash_balance", summary.get("total_cash", 0))) or 0)
+
+
+async def execute_order(signal: SignalMessage, *, trading_mode: str, buy_amount: float | None = None, limit_price: float | None = None) -> dict[str, Any]:
+    if signal.market == "US":
+        trader = USStockTrading(mode=trading_mode)
+        if signal.signal_type == "BUY":
+            return await trader.async_buy_stock(ticker=signal.ticker, buy_amount=buy_amount, limit_price=limit_price)
+        return await trader.async_sell_stock(ticker=signal.ticker, limit_price=limit_price)
+
+    async with AsyncTradingContext(mode=trading_mode) as trader:
+        if signal.signal_type == "BUY":
+            return await trader.async_buy_stock(
+                stock_code=signal.ticker,
+                buy_amount=None if buy_amount is None else int(buy_amount),
+                limit_price=None if limit_price is None else int(limit_price),
+            )
+        return await trader.async_sell_stock(
+            stock_code=signal.ticker,
+            limit_price=None if limit_price is None else int(limit_price),
+        )
+
+
+def execution_from_result(signal: SignalMessage, result: dict[str, Any], message_prefix: str, **details: Any) -> StrategyExecution:
+    broker_message = str(result.get("message", ""))
+    message = f"{message_prefix}: {broker_message}" if broker_message else message_prefix
+    return StrategyExecution(
+        status="executed" if result.get("success") else "failed",
+        message=message,
+        market=signal.market,
+        ticker=signal.ticker,
+        details=details or None,
+    )
+
+
+def load_json_list(path: Path) -> list[dict[str, Any]]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return []
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Ignoring unreadable strategy runtime file %s: %s", path, exc)
+        return []
+    return [item for item in payload if isinstance(item, dict)] if isinstance(payload, list) else []
+
+
+def save_json(path: Path, payload: Any) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Unable to save strategy runtime file %s: %s", path, exc)
+
+
+def fresh_items(items: list[dict[str, Any]], *, window: timedelta) -> list[dict[str, Any]]:
+    cutoff = datetime.now(timezone.utc) - window
+    fresh: list[dict[str, Any]] = []
+    for item in items:
+        try:
+            created_at = datetime.fromisoformat(str(item.get("created_at", "")))
+        except ValueError:
+            continue
+        if created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        if created_at >= cutoff:
+            fresh.append(item)
+    return fresh

--- a/trading/strategies/common.py
+++ b/trading/strategies/common.py
@@ -57,24 +57,40 @@ def available_cash(trader: StrategyTrader) -> float:
     return float(summary.get("available_amount", summary.get("cash_balance", summary.get("total_cash", 0))) or 0)
 
 
-async def execute_order(signal: SignalMessage, *, trading_mode: str, buy_amount: float | None = None, limit_price: float | None = None) -> dict[str, Any]:
+async def execute_order(signal: SignalMessage, *, trading_mode: str, buy_amount: float | None = None, limit_price: float | None = None, sell_fraction: float | None = None, trader_kwargs: dict[str, Any] | None = None) -> dict[str, Any]:
+    kwargs = {"mode": trading_mode, **(trader_kwargs or {})}
     if signal.market == "US":
-        trader = USStockTrading(mode=trading_mode)
+        trader = USStockTrading(**kwargs)
         if signal.signal_type == "BUY":
             return await trader.async_buy_stock(ticker=signal.ticker, buy_amount=buy_amount, limit_price=limit_price)
-        return await trader.async_sell_stock(ticker=signal.ticker, limit_price=limit_price)
+        
+        try:
+            return await trader.async_sell_stock(ticker=signal.ticker, limit_price=limit_price, sell_fraction=sell_fraction)
+        except TypeError:
+            if sell_fraction is not None and sell_fraction < 1:
+                return {"success": False, "ticker": signal.ticker, "quantity": 0, "message": "Partial sell fraction is not supported by this trader"}
+            return await trader.async_sell_stock(ticker=signal.ticker, limit_price=limit_price)
 
-    async with AsyncTradingContext(mode=trading_mode) as trader:
+    async with AsyncTradingContext(**kwargs) as trader:
         if signal.signal_type == "BUY":
             return await trader.async_buy_stock(
                 stock_code=signal.ticker,
                 buy_amount=None if buy_amount is None else int(buy_amount),
                 limit_price=None if limit_price is None else int(limit_price),
             )
-        return await trader.async_sell_stock(
-            stock_code=signal.ticker,
-            limit_price=None if limit_price is None else int(limit_price),
-        )
+        try:
+            return await trader.async_sell_stock(
+                stock_code=signal.ticker,
+                limit_price=None if limit_price is None else int(limit_price),
+                sell_fraction=sell_fraction,
+            )
+        except TypeError:
+            if sell_fraction is not None and sell_fraction < 1:
+                return {"success": False, "stock_code": signal.ticker, "quantity": 0, "message": "Partial sell fraction is not supported by this trader"}
+            return await trader.async_sell_stock(
+                stock_code=signal.ticker,
+                limit_price=None if limit_price is None else int(limit_price),
+            )
 
 
 def execution_from_result(signal: SignalMessage, result: dict[str, Any], message_prefix: str, **details: Any) -> StrategyExecution:

--- a/trading/strategies/cooldown.py
+++ b/trading/strategies/cooldown.py
@@ -1,5 +1,6 @@
 """Per-ticker cooldown guard strategy."""
 from __future__ import annotations
+import fcntl
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -24,14 +25,19 @@ class CooldownStrategy:
     def _key(self, signal: SignalMessage) -> str:
         if self.config.scope == "ticker": return signal.ticker
         return f"{signal.market}:{signal.ticker}:{signal.signal_type}"
-    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+    async def execute(self, signal: SignalMessage, *, trading_mode: str, trader_kwargs: dict[str, Any] | None = None) -> StrategyExecution:
         if signal.signal_type not in self.config.apply_to_signal_types:
-            result = await execute_order(signal, trading_mode=trading_mode, limit_price=signal.price)
+            result = await execute_order(signal, trading_mode=trading_mode, trader_kwargs=trader_kwargs, limit_price=signal.price)
             return execution_from_result(signal, result, "Cooldown pass-through")
-        key = self._key(signal); items = fresh_items(load_json_list(self.config.runtime_path), window=timedelta(minutes=self.config.window_minutes))
-        if any(item.get("key") == key for item in items): return StrategyExecution("rejected", f"Cooldown active for {key}", signal.market, signal.ticker)
-        result = await execute_order(signal, trading_mode=trading_mode, limit_price=signal.price)
-        execution = execution_from_result(signal, result, "Cooldown guarded execution")
-        if execution.status == "executed":
-            items.append({"key": key, "market": signal.market, "ticker": signal.ticker, "signal_type": signal.signal_type, "created_at": datetime.now(timezone.utc).isoformat()}); save_json(self.config.runtime_path, items)
-        return execution
+        key = self._key(signal)
+        lock_path = self.config.runtime_path.with_suffix(self.config.runtime_path.suffix + ".lock")
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("w", encoding="utf-8") as lock_file:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+            items = fresh_items(load_json_list(self.config.runtime_path), window=timedelta(minutes=self.config.window_minutes))
+            if any(item.get("key") == key for item in items): return StrategyExecution("rejected", f"Cooldown active for {key}", signal.market, signal.ticker)
+            result = await execute_order(signal, trading_mode=trading_mode, trader_kwargs=trader_kwargs, limit_price=signal.price)
+            execution = execution_from_result(signal, result, "Cooldown guarded execution")
+            if execution.status == "executed":
+                items.append({"key": key, "market": signal.market, "ticker": signal.ticker, "signal_type": signal.signal_type, "created_at": datetime.now(timezone.utc).isoformat()}); save_json(self.config.runtime_path, items)
+            return execution

--- a/trading/strategies/cooldown.py
+++ b/trading/strategies/cooldown.py
@@ -1,0 +1,37 @@
+"""Per-ticker cooldown guard strategy."""
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from ..schema import SignalMessage
+from .common import RUNTIME_DIR, StrategyExecution, execute_order, execution_from_result, fresh_items, load_json_list, save_json, strategy_name
+
+COOLDOWN = "cooldown"
+@dataclass(frozen=True, slots=True)
+class CooldownStrategyConfig:
+    window_minutes: int = 60; apply_to_signal_types: tuple[str, ...] = ("BUY",); scope: str = "market_ticker"; runtime_path: Path = RUNTIME_DIR / "cooldown_executions.json"
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "CooldownStrategyConfig | None":
+        if not payload or strategy_name(payload) != COOLDOWN: return None
+        window = int(payload.get("window_minutes", 60) or 60)
+        if window < 1: raise ValueError("signal_strategy.window_minutes must be 1 or greater")
+        types = tuple(str(v).strip().upper() for v in payload.get("apply_to_signal_types", ["BUY"]))
+        return cls(window, types, str(payload.get("scope", "market_ticker")), Path(payload.get("runtime_path") or (RUNTIME_DIR / "cooldown_executions.json")))
+
+class CooldownStrategy:
+    def __init__(self, *, config: CooldownStrategyConfig): self.config = config
+    def _key(self, signal: SignalMessage) -> str:
+        if self.config.scope == "ticker": return signal.ticker
+        return f"{signal.market}:{signal.ticker}:{signal.signal_type}"
+    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+        if signal.signal_type not in self.config.apply_to_signal_types:
+            result = await execute_order(signal, trading_mode=trading_mode, limit_price=signal.price)
+            return execution_from_result(signal, result, "Cooldown pass-through")
+        key = self._key(signal); items = fresh_items(load_json_list(self.config.runtime_path), window=timedelta(minutes=self.config.window_minutes))
+        if any(item.get("key") == key for item in items): return StrategyExecution("rejected", f"Cooldown active for {key}", signal.market, signal.ticker)
+        result = await execute_order(signal, trading_mode=trading_mode, limit_price=signal.price)
+        execution = execution_from_result(signal, result, "Cooldown guarded execution")
+        if execution.status == "executed":
+            items.append({"key": key, "market": signal.market, "ticker": signal.ticker, "signal_type": signal.signal_type, "created_at": datetime.now(timezone.utc).isoformat()}); save_json(self.config.runtime_path, items)
+        return execution

--- a/trading/strategies/event_risk_off.py
+++ b/trading/strategies/event_risk_off.py
@@ -20,16 +20,20 @@ class EventRiskOffStrategyConfig:
 
 class EventRiskOffStrategy:
     def __init__(self, *, config: EventRiskOffStrategyConfig): self.config = config
-    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+    async def execute(self, signal: SignalMessage, *, trading_mode: str, trader_kwargs: dict[str, Any] | None = None) -> StrategyExecution:
         if signal.is_event:
             if signal.event_type.strip().upper() in self.config.risk_off_event_types:
                 items = fresh_items(load_json_list(self.config.runtime_path), window=timedelta(minutes=self.config.risk_off_window_minutes))
                 items.append({"market": signal.market, "ticker": signal.ticker, "event_type": signal.event_type.upper(), "created_at": datetime.now(timezone.utc).isoformat()}); save_json(self.config.runtime_path, items)
                 return StrategyExecution("acknowledged", "Risk-off event recorded", signal.market, signal.ticker)
             return StrategyExecution("acknowledged", "Event signal acknowledged", signal.market, signal.ticker)
+        buy_amount = None
         if signal.signal_type == "BUY":
             items = fresh_items(load_json_list(self.config.runtime_path), window=timedelta(minutes=self.config.risk_off_window_minutes))
             active = any(item.get("ticker") in ("", signal.ticker) and item.get("market") in ("", signal.market) for item in items)
             if active and self.config.buy_size_multiplier <= 0: return StrategyExecution("rejected", "Risk-off state blocks BUY signals", signal.market, signal.ticker)
-        result = await execute_order(signal, trading_mode=trading_mode, limit_price=signal.price)
-        return execution_from_result(signal, result, "Event risk-off guarded execution")
+            if active:
+                configured_amount = signal.raw.get("buy_amount")
+                buy_amount = None if configured_amount in (None, "") else float(configured_amount) * self.config.buy_size_multiplier
+        result = await execute_order(signal, trading_mode=trading_mode, trader_kwargs=trader_kwargs, buy_amount=buy_amount, limit_price=signal.price)
+        return execution_from_result(signal, result, "Event risk-off guarded execution", buy_size_multiplier=self.config.buy_size_multiplier if buy_amount is not None else None)

--- a/trading/strategies/event_risk_off.py
+++ b/trading/strategies/event_risk_off.py
@@ -1,0 +1,35 @@
+"""Event-aware risk-off strategy state."""
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from ..schema import SignalMessage
+from .common import RUNTIME_DIR, StrategyExecution, execute_order, execution_from_result, fresh_items, load_json_list, save_json, strategy_name
+
+EVENT_RISK_OFF = "event_risk_off"
+@dataclass(frozen=True, slots=True)
+class EventRiskOffStrategyConfig:
+    risk_off_event_types: tuple[str, ...] = ("RISK_OFF",); risk_off_window_minutes: int = 1440; buy_size_multiplier: float = 0.0; runtime_path: Path = RUNTIME_DIR / "event_risk_off.json"
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "EventRiskOffStrategyConfig | None":
+        if not payload or strategy_name(payload) != EVENT_RISK_OFF: return None
+        window = int(payload.get("risk_off_window_minutes", 1440) or 1440)
+        if window < 1: raise ValueError("signal_strategy.risk_off_window_minutes must be 1 or greater")
+        return cls(tuple(str(v).strip().upper() for v in payload.get("risk_off_event_types", ["RISK_OFF"])), window, float(payload.get("buy_size_multiplier", 0.0)), Path(payload.get("runtime_path") or (RUNTIME_DIR / "event_risk_off.json")))
+
+class EventRiskOffStrategy:
+    def __init__(self, *, config: EventRiskOffStrategyConfig): self.config = config
+    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+        if signal.is_event:
+            if signal.event_type.strip().upper() in self.config.risk_off_event_types:
+                items = fresh_items(load_json_list(self.config.runtime_path), window=timedelta(minutes=self.config.risk_off_window_minutes))
+                items.append({"market": signal.market, "ticker": signal.ticker, "event_type": signal.event_type.upper(), "created_at": datetime.now(timezone.utc).isoformat()}); save_json(self.config.runtime_path, items)
+                return StrategyExecution("acknowledged", "Risk-off event recorded", signal.market, signal.ticker)
+            return StrategyExecution("acknowledged", "Event signal acknowledged", signal.market, signal.ticker)
+        if signal.signal_type == "BUY":
+            items = fresh_items(load_json_list(self.config.runtime_path), window=timedelta(minutes=self.config.risk_off_window_minutes))
+            active = any(item.get("ticker") in ("", signal.ticker) and item.get("market") in ("", signal.market) for item in items)
+            if active and self.config.buy_size_multiplier <= 0: return StrategyExecution("rejected", "Risk-off state blocks BUY signals", signal.market, signal.ticker)
+        result = await execute_order(signal, trading_mode=trading_mode, limit_price=signal.price)
+        return execution_from_result(signal, result, "Event risk-off guarded execution")

--- a/trading/strategies/limit_buffer.py
+++ b/trading/strategies/limit_buffer.py
@@ -1,0 +1,34 @@
+"""Buffered limit-price execution strategy."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+from ..schema import SignalMessage
+from .common import StrategyExecution, execute_order, execution_from_result, positive_number, strategy_name
+
+LIMIT_BUFFER = "limit_buffer"
+@dataclass(frozen=True, slots=True)
+class LimitBufferStrategyConfig:
+    buy_buffer_percent: float = 0.0; sell_buffer_percent: float = 0.0; us_price_decimals: int = 2; kr_tick_rounding: int = 1
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "LimitBufferStrategyConfig | None":
+        if not payload or strategy_name(payload) != LIMIT_BUFFER: return None
+        tick = int(payload.get("kr_tick_rounding", 1) or 1)
+        if tick < 1: raise ValueError("signal_strategy.kr_tick_rounding must be 1 or greater")
+        return cls(positive_number(payload,"buy_buffer_percent"), positive_number(payload,"sell_buffer_percent"), int(payload.get("us_price_decimals",2) or 2), tick)
+
+class LimitBufferStrategy:
+    def __init__(self, *, config: LimitBufferStrategyConfig): self.config = config
+    def _price(self, signal: SignalMessage) -> float:
+        if signal.price in (None, 0): raise ValueError("limit_buffer requires signal.price")
+        pct = self.config.buy_buffer_percent if signal.signal_type == "BUY" else -self.config.sell_buffer_percent
+        price = float(signal.price) * (1 + pct / 100)
+        if signal.market == "KR":
+            tick = self.config.kr_tick_rounding
+            return float(round(price / tick) * tick)
+        return round(price, self.config.us_price_decimals)
+    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+        if signal.signal_type not in {"BUY", "SELL"}: return StrategyExecution("rejected", "Limit buffer only supports trade signals", signal.market, signal.ticker)
+        try: limit_price = self._price(signal)
+        except ValueError as exc: return StrategyExecution("rejected", str(exc), signal.market, signal.ticker)
+        result = await execute_order(signal, trading_mode=trading_mode, limit_price=limit_price)
+        return execution_from_result(signal, result, f"Limit buffer {signal.signal_type} at {limit_price}", limit_price=limit_price)

--- a/trading/strategies/limit_buffer.py
+++ b/trading/strategies/limit_buffer.py
@@ -26,9 +26,9 @@ class LimitBufferStrategy:
             tick = self.config.kr_tick_rounding
             return float(round(price / tick) * tick)
         return round(price, self.config.us_price_decimals)
-    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+    async def execute(self, signal: SignalMessage, *, trading_mode: str, trader_kwargs: dict[str, Any] | None = None) -> StrategyExecution:
         if signal.signal_type not in {"BUY", "SELL"}: return StrategyExecution("rejected", "Limit buffer only supports trade signals", signal.market, signal.ticker)
         try: limit_price = self._price(signal)
         except ValueError as exc: return StrategyExecution("rejected", str(exc), signal.market, signal.ticker)
-        result = await execute_order(signal, trading_mode=trading_mode, limit_price=limit_price)
+        result = await execute_order(signal, trading_mode=trading_mode, trader_kwargs=trader_kwargs, limit_price=limit_price)
         return execution_from_result(signal, result, f"Limit buffer {signal.signal_type} at {limit_price}", limit_price=limit_price)

--- a/trading/strategies/profit_ladder.py
+++ b/trading/strategies/profit_ladder.py
@@ -20,7 +20,7 @@ class ProfitLadderStrategyConfig:
 
 class ProfitLadderStrategy:
     def __init__(self, *, config: ProfitLadderStrategyConfig): self.config = config
-    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+    async def execute(self, signal: SignalMessage, *, trading_mode: str, trader_kwargs: dict[str, Any] | None = None) -> StrategyExecution:
         if signal.signal_type != "SELL": return StrategyExecution("rejected", "Profit ladder strategy only supports SELL signals", signal.market, signal.ticker)
         reason = signal.sell_reason.strip().lower()
         sell_fraction = 1.0 if reason in self.config.full_exit_reasons else self.config.default_sell_percent
@@ -29,5 +29,5 @@ class ProfitLadderStrategy:
             for profit, fraction in sorted(self.config.profit_bands.items()):
                 if signal.profit_rate >= profit: sell_fraction = fraction
         if sell_fraction <= 0: return StrategyExecution("rejected", "Profit ladder sell fraction is zero", signal.market, signal.ticker)
-        result = await execute_order(signal, trading_mode=trading_mode, limit_price=signal.price)
+        result = await execute_order(signal, trading_mode=trading_mode, trader_kwargs=trader_kwargs, limit_price=signal.price, sell_fraction=sell_fraction)
         return execution_from_result(signal, result, f"Profit ladder sell fraction {sell_fraction:.2f}", sell_fraction=sell_fraction)

--- a/trading/strategies/profit_ladder.py
+++ b/trading/strategies/profit_ladder.py
@@ -1,0 +1,33 @@
+"""Profit-ladder SELL strategy."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+from ..schema import SignalMessage
+from .common import StrategyExecution, execute_order, execution_from_result, strategy_name
+
+PROFIT_LADDER = "profit_ladder"
+
+@dataclass(frozen=True, slots=True)
+class ProfitLadderStrategyConfig:
+    profit_bands: dict[float, float]; stop_loss_sell_percent: float = 1.0; default_sell_percent: float = 1.0; full_exit_reasons: tuple[str, ...] = ()
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "ProfitLadderStrategyConfig | None":
+        if not payload or strategy_name(payload) != PROFIT_LADDER: return None
+        bands = {float(k): float(v) for k, v in dict(payload.get("profit_bands") or {5: .25, 10: .5, 20: 1.0}).items()}
+        if any(v < 0 or v > 1 for v in bands.values()): raise ValueError("signal_strategy.profit_bands values must be between 0 and 1")
+        reasons = tuple(str(v).strip().lower() for v in payload.get("full_exit_reasons", ["stop_loss", "risk_off", "manual_exit"]))
+        return cls(bands, float(payload.get("stop_loss_sell_percent", 1.0)), float(payload.get("default_sell_percent", 1.0)), reasons)
+
+class ProfitLadderStrategy:
+    def __init__(self, *, config: ProfitLadderStrategyConfig): self.config = config
+    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+        if signal.signal_type != "SELL": return StrategyExecution("rejected", "Profit ladder strategy only supports SELL signals", signal.market, signal.ticker)
+        reason = signal.sell_reason.strip().lower()
+        sell_fraction = 1.0 if reason in self.config.full_exit_reasons else self.config.default_sell_percent
+        if reason == "stop_loss": sell_fraction = self.config.stop_loss_sell_percent
+        if signal.profit_rate is not None:
+            for profit, fraction in sorted(self.config.profit_bands.items()):
+                if signal.profit_rate >= profit: sell_fraction = fraction
+        if sell_fraction <= 0: return StrategyExecution("rejected", "Profit ladder sell fraction is zero", signal.market, signal.ticker)
+        result = await execute_order(signal, trading_mode=trading_mode, limit_price=signal.price)
+        return execution_from_result(signal, result, f"Profit ladder sell fraction {sell_fraction:.2f}", sell_fraction=sell_fraction)

--- a/trading/strategies/risk_bracket.py
+++ b/trading/strategies/risk_bracket.py
@@ -1,0 +1,39 @@
+"""Risk-based bracket BUY strategy."""
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from ..schema import SignalMessage
+from .common import RUNTIME_DIR, StrategyExecution, execute_order, execution_from_result, market_base_amount, positive_number, save_json, strategy_name, load_json_list
+
+RISK_BRACKET = "risk_bracket"
+
+@dataclass(frozen=True, slots=True)
+class RiskBracketStrategyConfig:
+    risk_amount_krw: float = 0.0; risk_amount_usd: float = 0.0; max_position_amount_krw: float = 0.0; max_position_amount_usd: float = 0.0; require_stop_loss: bool = True; require_target_price: bool = False
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "RiskBracketStrategyConfig | None":
+        if not payload or strategy_name(payload) != RISK_BRACKET: return None
+        return cls(positive_number(payload,"risk_amount_krw"), positive_number(payload,"risk_amount_usd"), positive_number(payload,"max_position_amount_krw"), positive_number(payload,"max_position_amount_usd"), bool(payload.get("require_stop_loss", True)), bool(payload.get("require_target_price", False)))
+
+class RiskBracketStrategy:
+    metadata_path = RUNTIME_DIR / "risk_brackets.json"
+    def __init__(self, *, config: RiskBracketStrategyConfig): self.config = config
+    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+        if signal.signal_type != "BUY": return StrategyExecution("rejected", "Risk bracket strategy only supports BUY signals", signal.market, signal.ticker)
+        if signal.price in (None, 0): return StrategyExecution("rejected", "Risk bracket strategy requires an entry price", signal.market, signal.ticker)
+        if self.config.require_stop_loss and signal.stop_loss is None: return StrategyExecution("rejected", "Risk bracket strategy requires stop_loss", signal.market, signal.ticker)
+        if self.config.require_target_price and signal.target_price is None: return StrategyExecution("rejected", "Risk bracket strategy requires target_price", signal.market, signal.ticker)
+        risk_budget = market_base_amount(signal, krw=self.config.risk_amount_krw, usd=self.config.risk_amount_usd)
+        if risk_budget <= 0: return StrategyExecution("failed", "Risk budget is zero", signal.market, signal.ticker)
+        per_unit_risk = float(signal.price) - float(signal.stop_loss or 0)
+        if per_unit_risk <= 0: return StrategyExecution("rejected", "stop_loss must be below entry price", signal.market, signal.ticker)
+        units_notional = int(risk_budget / per_unit_risk) * float(signal.price)
+        max_position = market_base_amount(signal, krw=self.config.max_position_amount_krw, usd=self.config.max_position_amount_usd)
+        buy_amount = min(units_notional, max_position) if max_position > 0 else units_notional
+        if buy_amount <= 0: return StrategyExecution("failed", "Risk bracket buy amount is zero", signal.market, signal.ticker)
+        result = await execute_order(signal, trading_mode=trading_mode, buy_amount=buy_amount, limit_price=signal.price)
+        execution = execution_from_result(signal, result, f"Risk bracket buy {buy_amount:.2f} with risk {risk_budget:.2f}", buy_amount=buy_amount, risk_budget=risk_budget)
+        if execution.status == "executed":
+            items = load_json_list(self.metadata_path); items.append({"market": signal.market, "ticker": signal.ticker, "entry_price": signal.price, "stop_loss": signal.stop_loss, "target_price": signal.target_price, "risk_budget": risk_budget, "created_at": datetime.now(timezone.utc).isoformat()}); save_json(self.metadata_path, items)
+        return execution

--- a/trading/strategies/risk_bracket.py
+++ b/trading/strategies/risk_bracket.py
@@ -19,7 +19,7 @@ class RiskBracketStrategyConfig:
 class RiskBracketStrategy:
     metadata_path = RUNTIME_DIR / "risk_brackets.json"
     def __init__(self, *, config: RiskBracketStrategyConfig): self.config = config
-    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+    async def execute(self, signal: SignalMessage, *, trading_mode: str, trader_kwargs: dict[str, Any] | None = None) -> StrategyExecution:
         if signal.signal_type != "BUY": return StrategyExecution("rejected", "Risk bracket strategy only supports BUY signals", signal.market, signal.ticker)
         if signal.price in (None, 0): return StrategyExecution("rejected", "Risk bracket strategy requires an entry price", signal.market, signal.ticker)
         if self.config.require_stop_loss and signal.stop_loss is None: return StrategyExecution("rejected", "Risk bracket strategy requires stop_loss", signal.market, signal.ticker)
@@ -32,7 +32,7 @@ class RiskBracketStrategy:
         max_position = market_base_amount(signal, krw=self.config.max_position_amount_krw, usd=self.config.max_position_amount_usd)
         buy_amount = min(units_notional, max_position) if max_position > 0 else units_notional
         if buy_amount <= 0: return StrategyExecution("failed", "Risk bracket buy amount is zero", signal.market, signal.ticker)
-        result = await execute_order(signal, trading_mode=trading_mode, buy_amount=buy_amount, limit_price=signal.price)
+        result = await execute_order(signal, trading_mode=trading_mode, trader_kwargs=trader_kwargs, buy_amount=buy_amount, limit_price=signal.price)
         execution = execution_from_result(signal, result, f"Risk bracket buy {buy_amount:.2f} with risk {risk_budget:.2f}", buy_amount=buy_amount, risk_budget=risk_budget)
         if execution.status == "executed":
             items = load_json_list(self.metadata_path); items.append({"market": signal.market, "ticker": signal.ticker, "entry_price": signal.price, "stop_loss": signal.stop_loss, "target_price": signal.target_price, "risk_budget": risk_budget, "created_at": datetime.now(timezone.utc).isoformat()}); save_json(self.metadata_path, items)

--- a/trading/strategies/score_weighted.py
+++ b/trading/strategies/score_weighted.py
@@ -25,7 +25,7 @@ class ScoreWeightedStrategyConfig:
 
 class ScoreWeightedStrategy:
     def __init__(self, *, config: ScoreWeightedStrategyConfig): self.config = config
-    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+    async def execute(self, signal: SignalMessage, *, trading_mode: str, trader_kwargs: dict[str, Any] | None = None) -> StrategyExecution:
         if signal.signal_type != "BUY":
             return StrategyExecution("rejected", "Score weighted strategy only supports BUY signals", signal.market, signal.ticker)
         if signal.buy_score is None or signal.buy_score < self.config.min_score:
@@ -36,5 +36,5 @@ class ScoreWeightedStrategy:
         buy_amount = market_base_amount(signal, krw=self.config.base_amount_krw, usd=self.config.base_amount_usd) * weight
         if buy_amount <= 0:
             return StrategyExecution("failed", "Score weighted buy amount is zero", signal.market, signal.ticker)
-        result = await execute_order(signal, trading_mode=trading_mode, buy_amount=buy_amount, limit_price=signal.price)
+        result = await execute_order(signal, trading_mode=trading_mode, trader_kwargs=trader_kwargs, buy_amount=buy_amount, limit_price=signal.price)
         return execution_from_result(signal, result, f"Score weighted buy {buy_amount:.2f} at weight {weight:.2f}", buy_amount=buy_amount, weight=weight)

--- a/trading/strategies/score_weighted.py
+++ b/trading/strategies/score_weighted.py
@@ -1,0 +1,40 @@
+"""Score-weighted BUY strategy."""
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Any
+from ..schema import SignalMessage
+from .common import StrategyExecution, execute_order, execution_from_result, market_base_amount, positive_number, strategy_name
+
+SCORE_WEIGHTED = "score_weighted"
+
+@dataclass(frozen=True, slots=True)
+class ScoreWeightedStrategyConfig:
+    base_amount_krw: float = 0.0
+    base_amount_usd: float = 0.0
+    min_score: int = 0
+    score_bands: dict[int, float] | None = None
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "ScoreWeightedStrategyConfig | None":
+        if not payload or strategy_name(payload) != SCORE_WEIGHTED:
+            return None
+        bands = payload.get("score_bands") or {60: 0.25, 75: 0.5, 90: 1.0}
+        parsed = {int(k): float(v) for k, v in dict(bands).items()}
+        if not parsed or any(v < 0 for v in parsed.values()):
+            raise ValueError("signal_strategy.score_bands must contain non-negative weights")
+        return cls(positive_number(payload, "base_amount_krw"), positive_number(payload, "base_amount_usd"), int(payload.get("min_score", 0) or 0), parsed)
+
+class ScoreWeightedStrategy:
+    def __init__(self, *, config: ScoreWeightedStrategyConfig): self.config = config
+    async def execute(self, signal: SignalMessage, *, trading_mode: str) -> StrategyExecution:
+        if signal.signal_type != "BUY":
+            return StrategyExecution("rejected", "Score weighted strategy only supports BUY signals", signal.market, signal.ticker)
+        if signal.buy_score is None or signal.buy_score < self.config.min_score:
+            return StrategyExecution("rejected", "BUY score is missing or below the configured threshold", signal.market, signal.ticker)
+        weight = 0.0
+        for score, band_weight in sorted((self.config.score_bands or {}).items()):
+            if signal.buy_score >= score: weight = band_weight
+        buy_amount = market_base_amount(signal, krw=self.config.base_amount_krw, usd=self.config.base_amount_usd) * weight
+        if buy_amount <= 0:
+            return StrategyExecution("failed", "Score weighted buy amount is zero", signal.market, signal.ticker)
+        result = await execute_order(signal, trading_mode=trading_mode, buy_amount=buy_amount, limit_price=signal.price)
+        return execution_from_result(signal, result, f"Score weighted buy {buy_amount:.2f} at weight {weight:.2f}", buy_amount=buy_amount, weight=weight)


### PR DESCRIPTION
### Motivation
- Introduce a set of opt-in strategies to provide configurable, policy-driven execution behavior (score-weighted sizing, risk-budgeted buys, profit-ladder sells, buffered limits, per-ticker cooldowns, and event-driven risk-off).
- Provide shared helpers and runtime persistence primitives to keep strategy implementations small and consistent.

### Description
- Add new strategy implementations under `trading/strategies/`: `score_weighted`, `risk_bracket`, `profit_ladder`, `limit_buffer`, `cooldown`, and `event_risk_off`, each with a config dataclass and `execute` method.
- Add `trading/strategies/common.py` with helper functions for order execution, runtime JSON persistence, time-window filtering, and config parsing utilities.
- Export new strategy symbols from `trading/strategies/__init__.py` and update `trading/strategies/README.md` with built-in strategy descriptions.
- Wire strategies into `TradeDispatcher` (`trading/dispatch.py`) by loading strategy configs, adding `_resolve_event_strategy` and a unified `_resolve_strategy` that selects the appropriate strategy for incoming signals, and adjust `_resolve_buy_strategy` to delegate to the resolver.
- Update example configuration `trading/config/kis_devlp.yaml.example` with new strategy options and defaults.
- Add unit tests in `tests/test_strategy_suite.py` that monkeypatch a fake US trader and exercise the new strategies' basic behaviors.

### Testing
- Added `tests/test_strategy_suite.py` covering `ScoreWeightedStrategy`, `ProfitLadderStrategyConfig`, `LimitBufferStrategy`, `RiskBracketStrategy` validation, `CooldownStrategy` behavior, and `EventRiskOffStrategy` event handling. 
- Ran the new strategy unit tests with `pytest` and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31742531508329b8d40ed330a6770f)