### PR TITLE
Add user-facing trading strategy guide

### DIFF
--- a/trading/STRATEGIES.md
+++ b/trading/STRATEGIES.md
@@ -1,0 +1,262 @@
+# Trading Strategy Guide
+
+This file explains every strategy in `trading/strategies` in simple words.
+
+Think of a **strategy** like a rule that tells the trading bot what to do when a signal arrives.
+A signal can say things like:
+
+- **BUY**: buy a stock.
+- **SELL**: sell a stock.
+- **EVENT**: remember that something important happened.
+
+Only one strategy is selected by `signal_strategy.name` in `trading/config/kis_devlp.yaml`.
+If `name` is empty, the bot uses the normal old behavior.
+
+## Quick list
+
+| Strategy name | Easy idea | Works with |
+| --- | --- | --- |
+| `balance_split` | Split the cash into equal pieces and buy with one piece. | BUY |
+| `score_weighted` | Buy more when the signal score is stronger. | BUY |
+| `risk_bracket` | Decide the buy size by how much money you are willing to risk. | BUY |
+| `profit_ladder` | Sell in steps as profit gets bigger, like climbing a ladder. | SELL |
+| `limit_buffer` | Move the limit price a little to help the order price. | BUY and SELL |
+| `cooldown` | Wait before trading the same thing again. | Usually BUY |
+| `event_risk_off` | Remember danger events and block or shrink buys for a while. | EVENT and BUY |
+
+## How to choose a strategy
+
+In `trading/config/kis_devlp.yaml`, set:
+
+```yaml
+signal_strategy:
+  name: "balance_split"
+```
+
+Replace `balance_split` with the strategy you want.
+Each strategy also has its own settings under `signal_strategy`.
+The example config file shows the available setting names, but this guide explains what they mean.
+
+## `balance_split`
+
+### In one sentence
+
+`balance_split` buys with one equal piece of the cash currently available.
+
+### Kid-friendly example
+
+You have 10 cookies and 2 friends.
+If `split_count` is `2`, you only give away half of the cookies now.
+The other half stays for later.
+
+### What it does
+
+- It only handles **BUY** signals.
+- It checks how much cash is available in the account.
+- It divides that cash by `split_count`.
+- It buys using that divided amount.
+
+### Main setting
+
+- `split_count`: how many equal pieces to split your available cash into.
+  - Example: `2` means use about half the cash.
+  - Example: `4` means use about one quarter of the cash.
+
+### When it is useful
+
+Use this when you do not want one BUY signal to spend all your cash.
+
+## `score_weighted`
+
+### In one sentence
+
+`score_weighted` buys a small, medium, or large amount depending on the signal's `buy_score`.
+
+### Kid-friendly example
+
+Imagine a teacher gives a stock idea a score.
+A score of 60 gets a small snack.
+A score of 90 gets a big snack.
+Better score, bigger buy.
+
+### What it does
+
+- It only handles **BUY** signals.
+- It reads `buy_score` from the signal.
+- If the score is too low, it does not buy.
+- If the score is high enough, it multiplies the base buy amount by a weight.
+
+### Main settings
+
+- `base_amount_krw`: base buy amount for Korean stocks.
+- `base_amount_usd`: base buy amount for U.S. stocks.
+- `min_score`: the minimum score needed before buying.
+- `score_bands`: score levels and their weights.
+  - Example: `60: 0.25` means buy 25% of the base amount when the score is at least 60.
+  - Example: `90: 1.0` means buy 100% of the base amount when the score is at least 90.
+
+### When it is useful
+
+Use this when your signal has a confidence score and you want stronger ideas to get more money.
+
+## `risk_bracket`
+
+### In one sentence
+
+`risk_bracket` chooses the buy size by looking at how much you could lose if the stop loss is hit.
+
+### Kid-friendly example
+
+You are playing a game and say, "I can lose only 1 sticker on this round."
+The strategy checks the entry price and stop-loss price, then decides how many shares fit that sticker limit.
+
+### What it does
+
+- It only handles **BUY** signals.
+- It needs an entry `price`.
+- It usually needs `stop_loss` too.
+- It calculates the gap between the buy price and the stop-loss price.
+- It uses your risk budget to decide the buy amount.
+- It can save bracket information like entry price, stop loss, and target price.
+
+### Main settings
+
+- `risk_amount_krw`: how much Korean won you are willing to risk.
+- `risk_amount_usd`: how many U.S. dollars you are willing to risk.
+- `max_position_amount_krw`: biggest Korean-stock position allowed by this strategy.
+- `max_position_amount_usd`: biggest U.S.-stock position allowed by this strategy.
+- `require_stop_loss`: whether the signal must include `stop_loss`.
+- `require_target_price`: whether the signal must include `target_price`.
+
+### When it is useful
+
+Use this when you care more about "how much can I lose if I am wrong?" than "how much should I spend?"
+
+## `profit_ladder`
+
+### In one sentence
+
+`profit_ladder` sells different portions as profit reaches different levels.
+
+### Kid-friendly example
+
+Imagine climbing stairs.
+At the first stair, you sell a little.
+At the next stair, you sell more.
+At the top stair, you may sell all.
+
+### What it does
+
+- It only handles **SELL** signals.
+- It reads `profit_rate` from the signal when available.
+- It chooses a sell fraction from `profit_bands`.
+- It can sell everything for important exit reasons like stop loss or risk off.
+
+### Main settings
+
+- `profit_bands`: profit levels and how much to sell.
+  - Example: `5: 0.25` means sell 25% when profit is at least 5%.
+  - Example: `20: 1.0` means sell 100% when profit is at least 20%.
+- `stop_loss_sell_percent`: how much to sell when the reason is `stop_loss`.
+- `default_sell_percent`: how much to sell if no special band or reason applies.
+- `full_exit_reasons`: reasons that should sell the whole position.
+
+### When it is useful
+
+Use this when you want to take profit step by step instead of selling everything at once.
+
+## `limit_buffer`
+
+### In one sentence
+
+`limit_buffer` changes the limit price a tiny bit before placing the order.
+
+### Kid-friendly example
+
+If a toy costs 100 coins and you really want to buy it, you might offer 100.1 coins.
+If you want to sell a toy, you might accept 99.9 coins.
+That tiny change is the buffer.
+
+### What it does
+
+- It handles **BUY** and **SELL** signals.
+- It requires the signal to include `price`.
+- For BUY, it can raise the limit price by a small percent.
+- For SELL, it can lower the limit price by a small percent.
+- It rounds prices for U.S. and Korean markets.
+
+### Main settings
+
+- `buy_buffer_percent`: how much to raise the BUY limit price.
+- `sell_buffer_percent`: how much to lower the SELL limit price.
+- `us_price_decimals`: how many decimal places to keep for U.S. prices.
+- `kr_tick_rounding`: how to round Korean stock prices by tick size.
+
+### When it is useful
+
+Use this when you want limit orders but also want a small cushion so they are more likely to fill.
+
+## `cooldown`
+
+### In one sentence
+
+`cooldown` stops the bot from trading the same thing again too soon.
+
+### Kid-friendly example
+
+After eating candy, a parent says, "Wait one hour before eating more candy."
+That waiting time is the cooldown.
+
+### What it does
+
+- It usually protects **BUY** signals, but it can be configured for other signal types.
+- It checks whether the same key traded recently.
+- If the key is still cooling down, it rejects the trade.
+- If enough time has passed, it lets the trade happen and records it.
+
+### Main settings
+
+- `window_minutes`: how long to wait before allowing the same key again.
+- `apply_to_signal_types`: signal types protected by cooldown, such as `BUY`.
+- `scope`: what counts as "the same thing".
+  - `market_ticker` uses market, ticker, and signal type together.
+  - `ticker` uses only the ticker.
+
+### When it is useful
+
+Use this to avoid repeated orders caused by duplicate signals or noisy alerts.
+
+## `event_risk_off`
+
+### In one sentence
+
+`event_risk_off` remembers danger events and blocks or shrinks BUY orders while the danger is fresh.
+
+### Kid-friendly example
+
+If the playground is wet, the teacher writes "wet playground" on the board.
+Until the note is old, kids cannot run there, or they must be extra careful.
+
+### What it does
+
+- It handles **EVENT** signals and **BUY** signals.
+- When it sees a risk-off event, it records it.
+- Later BUY signals for matching market/ticker can be blocked.
+- If configured, BUY signals can be made smaller instead of fully blocked.
+
+### Main settings
+
+- `risk_off_event_types`: event names that mean danger, such as `RISK_OFF`.
+- `risk_off_window_minutes`: how long the danger note stays active.
+- `buy_size_multiplier`: how much to multiply BUY size while risk-off is active.
+  - `0.0` means block the BUY.
+  - `0.5` means use half size.
+
+### When it is useful
+
+Use this when news, market stress, or another event should temporarily stop new buying.
+
+## Adding a new strategy
+
+When developers add a new strategy in `trading/strategies`, they must also update this file.
+Users should be able to open this guide and understand every available strategy without reading Python code.

--- a/trading/STRATEGIES.md
+++ b/trading/STRATEGIES.md
@@ -116,6 +116,7 @@ The strategy checks the entry price and stop-loss price, then decides how many s
 - It needs an entry `price`.
 - It usually needs `stop_loss` too.
 - It calculates the gap between the buy price and the stop-loss price.
+- If `require_stop_loss` is `false` and the signal omits `stop_loss`, the strategy sizes the trade as if the stop loss were `0`, which can make the calculated position very small or reject the trade.
 - It uses your risk budget to decide the buy amount.
 - It can save bracket information like entry price, stop loss, and target price.
 
@@ -125,7 +126,7 @@ The strategy checks the entry price and stop-loss price, then decides how many s
 - `risk_amount_usd`: how many U.S. dollars you are willing to risk.
 - `max_position_amount_krw`: biggest Korean-stock position allowed by this strategy.
 - `max_position_amount_usd`: biggest U.S.-stock position allowed by this strategy.
-- `require_stop_loss`: whether the signal must include `stop_loss`.
+- `require_stop_loss`: whether the signal must include `stop_loss`; even when this is `false`, include a meaningful `stop_loss` if you want normal stop-loss-based sizing.
 - `require_target_price`: whether the signal must include `target_price`.
 
 ### When it is useful
@@ -150,7 +151,8 @@ At the top stair, you may sell all.
 - It only handles **SELL** signals.
 - It reads `profit_rate` from the signal when available.
 - It chooses a sell fraction from `profit_bands`.
-- It can sell everything for important exit reasons like stop loss or risk off.
+- It can sell everything for important exit reasons like stop loss or risk off when no profit band overrides that amount.
+- If a SELL signal has both a `full_exit_reasons` reason and `profit_rate`, the matching `profit_bands` value decides the final sell fraction.
 
 ### Main settings
 
@@ -159,7 +161,7 @@ At the top stair, you may sell all.
   - Example: `20: 1.0` means sell 100% when profit is at least 20%.
 - `stop_loss_sell_percent`: how much to sell when the reason is `stop_loss`.
 - `default_sell_percent`: how much to sell if no special band or reason applies.
-- `full_exit_reasons`: reasons that should sell the whole position.
+- `full_exit_reasons`: reasons that start as a whole-position sell; if `profit_rate` is also present, the profit ladder can replace this with a partial sell fraction from `profit_bands`.
 
 ### When it is useful
 
@@ -184,13 +186,14 @@ That tiny change is the buffer.
 - For BUY, it can raise the limit price by a small percent.
 - For SELL, it can lower the limit price by a small percent.
 - It rounds prices for U.S. and Korean markets.
+- For Korean stocks, tick rounding happens after the buffer is added or subtracted, so a small buffer can round back to the original price when `kr_tick_rounding` is larger than the buffered price change.
 
 ### Main settings
 
 - `buy_buffer_percent`: how much to raise the BUY limit price.
 - `sell_buffer_percent`: how much to lower the SELL limit price.
 - `us_price_decimals`: how many decimal places to keep for U.S. prices.
-- `kr_tick_rounding`: how to round Korean stock prices by tick size.
+- `kr_tick_rounding`: how to round Korean stock prices by tick size; choose a buffer large enough to survive this rounding if you need the limit price to move.
 
 ### When it is useful
 
@@ -250,7 +253,8 @@ Until the note is old, kids cannot run there, or they must be extra careful.
 - `risk_off_window_minutes`: how long the danger note stays active.
 - `buy_size_multiplier`: how much to multiply BUY size while risk-off is active.
   - `0.0` means block the BUY.
-  - `0.5` means use half size.
+  - `0.5` means use half of the explicit `buy_amount` in the signal.
+  - If the BUY signal does not include `raw.buy_amount`, the multiplier cannot shrink the broker/config default order size; it passes no custom buy amount.
 
 ### When it is useful
 

--- a/trading/config/kis_devlp.yaml.example
+++ b/trading/config/kis_devlp.yaml.example
@@ -115,18 +115,13 @@ accounts:
 # -----------------------------------------------------------------------------
 
 # 신호 기반 전략 설정
-# - name: ""              기존 동작 유지 (전략 비활성화)
-# - name: "balance_split" BUY 신호마다 현재 주문 가능 잔고의 1/split_count만 매수
-# - name: "score_weighted" buy_score 구간별 비중으로 매수 금액 조정
-# - name: "risk_bracket" stop_loss/target_price 기반 리스크 예산 매수
-# - name: "profit_ladder" profit_rate/sell_reason 기반 단계적 SELL
-# - name: "limit_buffer" BUY/SELL 지정가에 완충 비율 적용
-# - name: "cooldown" 같은 종목/신호의 반복 주문 방지
-# - name: "event_risk_off" EVENT 신호로 임시 risk-off 상태 기록
+# 자세한 전략 설명은 trading/STRATEGIES.md 파일을 읽어보세요.
+# - name: "" 기존 동작 유지 (전략 비활성화)
+# - name: "balance_split", "score_weighted", "risk_bracket", "profit_ladder",
+#         "limit_buffer", "cooldown", "event_risk_off" 중 하나를 선택할 수 있습니다.
 signal_strategy:
   name: ""
   split_count: 2
-  # score_weighted
   base_amount_krw: 50000
   base_amount_usd: 100
   min_score: 60
@@ -134,14 +129,12 @@ signal_strategy:
     60: 0.25
     75: 0.5
     90: 1.0
-  # risk_bracket
   risk_amount_krw: 10000
   risk_amount_usd: 25
   max_position_amount_krw: 100000
   max_position_amount_usd: 500
   require_stop_loss: true
   require_target_price: false
-  # profit_ladder
   profit_bands:
     5: 0.25
     10: 0.5
@@ -152,17 +145,14 @@ signal_strategy:
     - stop_loss
     - risk_off
     - manual_exit
-  # limit_buffer
   buy_buffer_percent: 0.1
   sell_buffer_percent: 0.1
   us_price_decimals: 2
   kr_tick_rounding: 1
-  # cooldown
   window_minutes: 60
   apply_to_signal_types:
     - BUY
   scope: "market_ticker"
-  # event_risk_off
   risk_off_event_types:
     - RISK_OFF
   risk_off_window_minutes: 1440

--- a/trading/strategies/README.md
+++ b/trading/strategies/README.md
@@ -44,7 +44,9 @@ strategy.
 8. **Document the user-facing config** in
    `trading/config/kis_devlp.yaml.example`, including the strategy name and each
    supported option.
-9. **Add tests** that cover config parsing, disabled or mismatched strategy
+9. **Update the user strategy guide** in `trading/STRATEGIES.md`. Every new
+   strategy must be added there so users can understand it without reading code.
+10. **Add tests** that cover config parsing, disabled or mismatched strategy
    names, successful execution, rejection paths, and dispatcher routing.
 
 Strategies should be opt-in and should preserve the legacy execution path when


### PR DESCRIPTION
### Motivation
- Make the available trading policies easy for end users to read without opening Python code by moving plain-language descriptions out of config comments and into a single guide. 
- Replace long inline config comments with a short pointer to a human-friendly guide so `trading/config/kis_devlp.yaml.example` stays compact. 
- Ensure future strategies are documented for users by adding a required maintenance step to developer docs. 

### Description
- Add `trading/STRATEGIES.md`, a kid-friendly, plain-language guide that explains each built-in strategy (`balance_split`, `score_weighted`, `risk_bracket`, `profit_ladder`, `limit_buffer`, `cooldown`, `event_risk_off`) with examples, behavior, key settings, and when to use them. 
- Update `trading/config/kis_devlp.yaml.example` to shorten the inline strategy comments and point users to `trading/STRATEGIES.md`, while preserving the example `signal_strategy` fields. 
- Update `trading/strategies/README.md` to require that developers add any new strategy to `trading/STRATEGIES.md` as part of the new-strategy checklist. 

### Testing
- Verified the new guide and modified files exist and contain content using a small Python path-check script (`python` script that printed existence and line counts), and that check succeeded. 
- Attempted to validate `trading/config/kis_devlp.yaml.example` via `yaml.safe_load`, but that run failed due to the environment missing the `PyYAML` module, so YAML parsing could not be completed here. 
- Ran a basic repository status check (`git status --short`) to confirm the three files were updated/added in the working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a317c0559ec83298d2656cd36011247)