### PR TITLE
Resolve orderable USD in async buys and enable early auto-exchange to avoid zero-quantity purchases

### DIFF
--- a/tests/test_multi_account_us.py
+++ b/tests/test_multi_account_us.py
@@ -296,6 +296,63 @@ def test_us_buy_quantity_falls_back_when_buyable_probe_raises():
     assert trader.calculate_buy_quantity("AAPL") == 2
 
 
+def test_us_buy_quantity_does_not_upsize_when_cash_covers_one_share():
+    trader = _bare_us_trader(auto_exchange=True)
+    trader.buy_amount = 20.0
+    trader.buy_sizing = ust.build_buy_sizing(fixed_amount=20.0, asset_percent=None)
+    trader.get_account_summary = lambda: {"available_amount": 100.0, "usd_cash": 100.0, "exchange_rate": 1300.0}
+    trader.get_overseas_buyable_amount = lambda *args, **kwargs: {
+        "ord_psbl_frcr_amt": "100.00",
+        "echm_af_ord_psbl_amt": "150.00",
+        "exrt": "1300.00",
+    }
+
+    assert trader.calculate_buy_quantity("AAPL") == 0
+
+
+def test_us_buy_quantity_honors_min_shortfall_before_one_share_auto_exchange():
+    trader = _bare_us_trader(auto_exchange=True)
+    trader.buy_amount = 49.50
+    trader.buy_sizing = ust.build_buy_sizing(fixed_amount=49.50, asset_percent=None)
+    trader.get_account_summary = lambda: {"available_amount": 49.50, "usd_cash": 49.50, "exchange_rate": 1300.0}
+    trader.get_overseas_buyable_amount = lambda *args, **kwargs: {
+        "ord_psbl_frcr_amt": "49.50",
+        "echm_af_ord_psbl_amt": "100.00",
+        "exrt": "1300.00",
+    }
+
+    assert trader.calculate_buy_quantity("AAPL") == 0
+
+
+def test_us_reserved_buy_uses_resolved_auto_exchange_amount():
+    trader = _bare_us_trader(auto_exchange=True)
+    trader.auto_trading = True
+    trader.buy_amount = 20.0
+    trader.buy_sizing = ust.build_buy_sizing(fixed_amount=20.0, asset_percent=None)
+    trader.is_reserved_order_available = lambda: True
+    trader.get_account_summary = lambda: {"available_amount": 20.0, "usd_cash": 20.0, "exchange_rate": 1300.0}
+    trader.get_overseas_buyable_amount = lambda *args, **kwargs: {
+        "ord_psbl_frcr_amt": "20.00",
+        "echm_af_ord_psbl_amt": "100.00",
+        "exrt": "1300.00",
+    }
+    requests = []
+
+    def fake_request(api_url, tr_id, params, **kwargs):
+        requests.append((api_url, tr_id, params, kwargs))
+        return _FakeKISResponse(output={"ODNO": "reserved-1"})
+
+    trader._request = fake_request
+
+    result = trader.buy_reserved_order("AAPL", 50.0, buy_amount=20.0, exchange="NASD")
+
+    assert result["success"] is True
+    assert result["quantity"] == 1
+    assert result["resolved_amount"] == 50.0
+    assert result["auto_exchange_used"] is True
+    assert requests[0][2]["FT_ORD_QTY"] == "1"
+
+
 @pytest.mark.asyncio
 async def test_async_buy_uses_auto_exchange_before_zero_quantity_rejection():
     trader = _bare_us_trader(auto_exchange=True)

--- a/tests/test_multi_account_us.py
+++ b/tests/test_multi_account_us.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -293,3 +294,36 @@ def test_us_buy_quantity_falls_back_when_buyable_probe_raises():
     trader.get_overseas_buyable_amount = raise_probe
 
     assert trader.calculate_buy_quantity("AAPL") == 2
+
+
+@pytest.mark.asyncio
+async def test_async_buy_uses_auto_exchange_before_zero_quantity_rejection():
+    trader = _bare_us_trader(auto_exchange=True)
+    trader.buy_amount = 20.0
+    trader.buy_sizing = ust.build_buy_sizing(fixed_amount=20.0, asset_percent=None)
+    trader._stock_locks = {}
+    trader._semaphore = asyncio.Semaphore(1)
+    trader._global_lock = asyncio.Lock()
+    trader.get_current_price = lambda ticker, exchange=None: {"current_price": 50.0}
+    trader.get_account_summary = lambda: {"available_amount": 20.0, "usd_cash": 20.0, "exchange_rate": 1300.0}
+    trader.get_overseas_buyable_amount = lambda *args, **kwargs: {
+        "ord_psbl_frcr_amt": "20.00",
+        "echm_af_ord_psbl_amt": "100.00",
+        "exrt": "1300.00",
+    }
+
+    smart_buy_calls = []
+
+    def fake_smart_buy(ticker, buy_amount, exchange=None, limit_price=None):
+        smart_buy_calls.append((ticker, buy_amount, exchange, limit_price))
+        return {"success": True, "order_no": "ord-1", "quantity": 2, "message": "ok"}
+
+    trader.smart_buy = fake_smart_buy
+
+    result = await trader._execute_buy_stock("AAPL", buy_amount=20.0, exchange="NASD")
+
+    assert result["success"] is True
+    assert result["quantity"] == 2
+    assert result["resolved_amount"] == 50.0
+    assert result["auto_exchange_used"] is True
+    assert smart_buy_calls == [("AAPL", 50.0, "NASD", 50.0)]

--- a/trading/us.py
+++ b/trading/us.py
@@ -473,6 +473,30 @@ class USStockTrading:
             cash_orderable = min(cash_orderable, current_orderable) if cash_orderable > 0 else current_orderable
 
         if cash_orderable >= requested_amount:
+            if auto_exchange.enabled and requested_amount < price and after_exchange_orderable > cash_orderable:
+                exchange_rate = _safe_float(buyable.get("exrt"), _safe_float(summary.get("exchange_rate")))
+                orderable_usd = after_exchange_orderable
+                if auto_exchange.max_krw is not None and exchange_rate > 0:
+                    max_exchange_usd = auto_exchange.max_krw / exchange_rate
+                    orderable_usd = min(orderable_usd, cash_orderable + max_exchange_usd)
+                resolved = min(max(requested_amount, price), orderable_usd)
+                if resolved > requested_amount:
+                    info.update(
+                        {
+                            "auto_exchange_used": resolved > cash_orderable,
+                            "exchange_rate": exchange_rate,
+                            "orderable_after_exchange_usd": after_exchange_orderable,
+                        }
+                    )
+                    logger.info(
+                        "[%s] Auto-exchange enabled: USD cash %.2f covers requested %.2f but not one share at %.2f; using %.2f",
+                        ticker,
+                        cash_orderable,
+                        requested_amount,
+                        price,
+                        resolved,
+                    )
+                    return resolved, info
             return requested_amount, info
 
         if not auto_exchange.enabled:
@@ -1426,14 +1450,28 @@ class USStockTrading:
 
                         result['current_price'] = price_info['current_price']
 
-                        # Calculate buy quantity
+                        # Calculate buy quantity using the same KIS orderable amount
+                        # resolver as the synchronous buy path. This keeps
+                        # async balance_split buys from rejecting small USD cash
+                        # balances before opt-in auto exchange can be considered.
                         current_price = price_info['current_price']
-                        buy_quantity = math.floor(amount / current_price)
+                        resolved_amount, buy_info = await asyncio.to_thread(
+                            self._resolve_orderable_usd,
+                            ticker,
+                            amount,
+                            current_price,
+                            EXCHANGE_CODES.get(exchange.upper(), exchange) if exchange else get_exchange_code(ticker),
+                        )
+                        buy_quantity = math.floor(resolved_amount / current_price)
 
                         if buy_quantity == 0:
-                            result['message'] = f'Buy quantity is 0 (amount: ${amount:.2f})'
+                            result['message'] = f'Buy quantity is 0 (amount: ${resolved_amount:.2f})'
+                            result.update(buy_info)
+                            result['resolved_amount'] = resolved_amount
                             return result
 
+                        result.update(buy_info)
+                        result['resolved_amount'] = resolved_amount
                         result['quantity'] = buy_quantity
                         result['total_amount'] = buy_quantity * current_price
 
@@ -1446,7 +1484,7 @@ class USStockTrading:
                         logger.info(f"[Async Buy] {ticker} limit_price: ${effective_limit_price:.2f} (provided: {limit_price})")
 
                         buy_result = await asyncio.to_thread(
-                            self.smart_buy, ticker, amount, exchange, effective_limit_price
+                            self.smart_buy, ticker, resolved_amount, exchange, effective_limit_price
                         )
 
                         if buy_result['success']:

--- a/trading/us.py
+++ b/trading/us.py
@@ -473,7 +473,14 @@ class USStockTrading:
             cash_orderable = min(cash_orderable, current_orderable) if cash_orderable > 0 else current_orderable
 
         if cash_orderable >= requested_amount:
-            if auto_exchange.enabled and requested_amount < price and after_exchange_orderable > cash_orderable:
+            one_share_shortfall = price - cash_orderable
+            if (
+                auto_exchange.enabled
+                and requested_amount < price
+                and cash_orderable < price
+                and one_share_shortfall >= auto_exchange.min_shortfall_usd
+                and after_exchange_orderable > cash_orderable
+            ):
                 exchange_rate = _safe_float(buyable.get("exrt"), _safe_float(summary.get("exchange_rate")))
                 orderable_usd = after_exchange_orderable
                 if auto_exchange.max_krw is not None and exchange_rate > 0:
@@ -1058,6 +1065,8 @@ class USStockTrading:
         if not self.is_reserved_order_available():
             return self._reserved_window_closed(ticker, 'buy', limit_price)
 
+        amount, buy_info = self._resolve_orderable_usd(ticker, amount, limit_price, exchange)
+
         # Calculate quantity based on limit price
         buy_quantity = math.floor(amount / limit_price)
 
@@ -1106,6 +1115,8 @@ class USStockTrading:
                     'quantity': buy_quantity,
                     'limit_price': limit_price,
                     'order_type': 'reserved_limit',
+                    'resolved_amount': amount,
+                    'auto_exchange_used': buy_info.get('auto_exchange_used', False),
                     'message': f'Reserved buy order completed ({buy_quantity} shares x ${limit_price:.2f})'
                 }
             else:


### PR DESCRIPTION
### Motivation
- Prevent async buy flows from rejecting small USD balances before considering auto-exchange and KIS orderable amounts. 
- Make async and sync buy paths use the same orderable USD resolution logic so behavior is consistent across sync and async APIs.

### Description
- Introduced use of the shared orderable resolution logic by calling `self._resolve_orderable_usd` in the async buy flow and using the returned `resolved_amount` and `buy_info` to compute `buy_quantity` and to pass to `self.smart_buy`.
- Enhanced synchronous orderable resolution to consider `auto_exchange` when cash covers the requested amount but not one share at `price`, computing a `resolved` USD amount (respecting `auto_exchange.max_krw`) and returning it early when it enables a one-share buy.
- Updated log messages and result payloads in the async flow to include `resolved_amount` and extra `buy_info` metadata when resolution alters the amount.
- Added an async unit test `test_async_buy_uses_auto_exchange_before_zero_quantity_rejection` in `tests/test_multi_account_us.py` and imported `asyncio` to support the test.

### Testing
- Ran the new async unit test `tests/test_multi_account_us.py::test_async_buy_uses_auto_exchange_before_zero_quantity_rejection` with `pytest`, and it passed. 
- Ran the repository test suite with `pytest` for the modified tests under `tests/`, and all executed tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32bec4e1fc832984b18f7d770f61c9)