### PR TITLE
Cap KR buy amount by broker orderable cash and add tests

### DIFF
--- a/tests/test_balance_split_strategy.py
+++ b/tests/test_balance_split_strategy.py
@@ -136,6 +136,36 @@ async def test_balance_split_caps_orderable_cash_at_cash_balance_excluding_holdi
 
 
 @pytest.mark.asyncio
+async def test_kr_balance_split_caps_final_buy_amount_by_orderable_cash():
+    trader = FakeKRTrader(available_amount=3000, deposit=30000, total_cash=12000)
+    strategy = BalanceSplitStrategy(config=BalanceSplitStrategyConfig(split_count=3))
+    signal = parse_signal_payload({"type": "BUY", "ticker": "005930", "market": "KR", "price": 80000})
+
+    result = await strategy._execute_kr(signal, trader=trader)
+
+    assert result.status == "executed"
+    assert result.available_amount == 12000
+    assert result.buy_amount == 3000.0
+    assert result.cash_source == "cash_balance-capped-by-available_amount"
+    assert trader.buy_calls == [("005930", 3000, 80000)]
+
+
+@pytest.mark.asyncio
+async def test_kr_balance_split_uses_cash_balance_base_when_orderable_cash_exceeds_target():
+    trader = FakeKRTrader(available_amount=3000, deposit=30000, total_cash=12000)
+    strategy = BalanceSplitStrategy(config=BalanceSplitStrategyConfig(split_count=4))
+    signal = parse_signal_payload({"type": "BUY", "ticker": "005930", "market": "KR", "price": 80000})
+
+    result = await strategy._execute_kr(signal, trader=trader)
+
+    assert result.status == "executed"
+    assert result.available_amount == 12000
+    assert result.buy_amount == 3000.0
+    assert result.cash_source == "cash_balance"
+    assert trader.buy_calls == [("005930", 3000, 80000)]
+
+
+@pytest.mark.asyncio
 async def test_kr_balance_split_deducts_recent_successful_buys_when_broker_cash_is_stale(tmp_path):
     strategy = BalanceSplitStrategy(config=BalanceSplitStrategyConfig(split_count=2))
     strategy.reservation_path = tmp_path / "balance_split_reservations.json"

--- a/trading/strategies/balance_split.py
+++ b/trading/strategies/balance_split.py
@@ -99,6 +99,11 @@ class BalanceSplitStrategy:
     async def _execute_kr(self, signal: SignalMessage, *, trader: _BuyTrader) -> BalanceSplitExecution:
         available_amount, cash_source, summary = self._available_amount(trader, market="KR")
         buy_amount = self._buy_amount(available_amount)
+        buy_amount, cash_source = self._cap_buy_amount_for_orderability(
+            buy_amount=buy_amount,
+            cash_source=cash_source,
+            summary=summary,
+        )
         if buy_amount <= 0:
             return self._no_balance(signal, available_amount, buy_amount, cash_source=cash_source)
 
@@ -135,17 +140,13 @@ class BalanceSplitStrategy:
 
         # For domestic accounts, cash_balance/total_cash is the cash portion of
         # the account after excluding current stock holdings.  That is the
-        # intended balance_split base.  KIS can report ord_psbl_cash=0 outside
-        # regular hours, so use the cash balance in that case; when both values
-        # are positive, cap at the lower value so the strategy never overstates
-        # cash because of stale or more permissive broker fields.
+        # intended balance_split sizing base.  KIS can report ord_psbl_cash=0
+        # outside regular hours, so keep orderability separate from strategy
+        # sizing and cap the final order amount later only when a positive
+        # orderable cash value is available.
         if cash_balance > 0:
-            if available_amount > 0:
-                cash_amount = min(cash_balance, available_amount)
-                cash_source = "available_amount" if available_amount <= cash_balance else "cash_balance"
-            else:
-                cash_amount = cash_balance
-                cash_source = "cash_balance"
+            cash_amount = cash_balance
+            cash_source = "cash_balance"
             reserved_amount = self._pending_reserved_amount(
                 market=market, current_cash=cash_amount, account_key=account_key
             )
@@ -188,6 +189,29 @@ class BalanceSplitStrategy:
             return adjusted_deposit, cash_source, summary
 
         return 0.0, "available_amount", summary
+
+    @staticmethod
+    def _cap_buy_amount_for_orderability(
+        *,
+        buy_amount: float,
+        cash_source: str,
+        summary: dict[str, Any],
+    ) -> tuple[float, str]:
+        """Cap the final order by positive broker-reported orderable cash.
+
+        The balance split sizing base can legitimately include settlement-aware
+        cash fields such as domestic D+2 receivables.  A positive
+        available_amount, however, is still useful as a safety cap for the
+        actual order submitted to the broker.  A zero value is intentionally not
+        used as a hard cap because KIS can return zero outside regular hours.
+        """
+        try:
+            orderable_cash = float(summary.get("available_amount", 0) or 0)
+        except (TypeError, ValueError):
+            orderable_cash = 0.0
+        if orderable_cash <= 0 or buy_amount <= orderable_cash:
+            return buy_amount, cash_source
+        return orderable_cash, f"{cash_source}-capped-by-available_amount"
 
     def _load_reservations(self) -> list[dict[str, Any]]:
         try:


### PR DESCRIPTION
### Motivation
- Prevent submitted KR orders from exceeding the broker-reported orderable cash while keeping balance-split sizing based on cash-like fields such as `cash_balance` or `deposit`.
- Avoid using a zero `available_amount` value as a hard cap because some brokers (KIS) may report zero outside regular hours.
- Add unit tests to cover the new capping behavior and the case where orderable cash exceeds the per-split target.

### Description
- Changed `_available_amount` to use `cash_balance` as the primary sizing base and stop capping it by `available_amount` at that stage, while preserving reservation adjustments and logging.
- Added a new helper `@staticmethod _cap_buy_amount_for_orderability` that caps the final `buy_amount` by a positive broker-reported `available_amount` and updates the `cash_source` suffix when capping occurs.
- Applied the new cap in `_execute_kr` before placing the order so the orderable cash is enforced only at submission time and not when computing the sizing base.
- Added two tests in `tests/test_balance_split_strategy.py`: `test_kr_balance_split_caps_final_buy_amount_by_orderable_cash` and `test_kr_balance_split_uses_cash_balance_base_when_orderable_cash_exceeds_target` to validate the new behavior.

### Testing
- Ran `pytest tests/test_balance_split_strategy.py` which includes the new tests and existing balance-split coverage, and all tests passed.
- Existing balance-split tests continued to pass after the refactor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34e08341f08329b80419580a4724db)