### PR TITLE
Add stop-loss sell strategy and make it the default

### DIFF
--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -205,3 +205,52 @@ async def test_disabled_strategy_buy_uses_legacy_path(monkeypatch):
 
     assert result.status == "executed"
     assert results == {"mode": "demo", "ticker": "AAPL", "limit_price": 200.0}
+
+
+@pytest.mark.asyncio
+async def test_stop_loss_sell_strategy_uses_stop_loss_limit(monkeypatch):
+    results = {}
+
+    class FakeUSTrader:
+        def __init__(self, mode):
+            results["mode"] = mode
+
+        async def async_sell_stock(self, ticker, limit_price=None, sell_fraction=None):
+            results["ticker"] = ticker
+            results["limit_price"] = limit_price
+            results["sell_fraction"] = sell_fraction
+            return {"success": True, "message": "stop-loss-sell"}
+
+    monkeypatch.setattr("trading.strategies.common.USStockTrading", FakeUSTrader)
+    monkeypatch.setattr("trading.dispatch.is_market_open", lambda market: True)
+
+    dispatcher = TradeDispatcher(trading_mode="demo", strategy_config={"name": "stop_loss_sell"})
+    signal = parse_signal_payload({"type": "SELL", "ticker": "AAPL", "market": "US", "price": 200, "stop_loss": 180})
+    result = await dispatcher.dispatch(signal)
+
+    assert result.status == "executed"
+    assert results == {"mode": "demo", "ticker": "AAPL", "limit_price": 180.0, "sell_fraction": None}
+
+
+@pytest.mark.asyncio
+async def test_stop_loss_sell_strategy_falls_back_to_signal_price(monkeypatch):
+    results = {}
+
+    class FakeUSTrader:
+        def __init__(self, mode):
+            results["mode"] = mode
+
+        async def async_sell_stock(self, ticker, limit_price=None, sell_fraction=None):
+            results["ticker"] = ticker
+            results["limit_price"] = limit_price
+            return {"success": True, "message": "fallback-sell"}
+
+    monkeypatch.setattr("trading.strategies.common.USStockTrading", FakeUSTrader)
+    monkeypatch.setattr("trading.dispatch.is_market_open", lambda market: True)
+
+    dispatcher = TradeDispatcher(trading_mode="demo", strategy_config={"name": "stop_loss_sell"})
+    signal = parse_signal_payload({"type": "SELL", "ticker": "AAPL", "market": "US", "price": 200})
+    result = await dispatcher.dispatch(signal)
+
+    assert result.status == "executed"
+    assert results == {"mode": "demo", "ticker": "AAPL", "limit_price": 200.0}

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -208,7 +208,7 @@ async def test_disabled_strategy_buy_uses_legacy_path(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_stop_loss_sell_strategy_uses_stop_loss_limit(monkeypatch):
+async def test_stop_loss_sell_strategy_uses_stop_loss_limit_above_signal_price(monkeypatch):
     results = {}
 
     class FakeUSTrader:
@@ -230,6 +230,31 @@ async def test_stop_loss_sell_strategy_uses_stop_loss_limit(monkeypatch):
 
     assert result.status == "executed"
     assert results == {"mode": "demo", "ticker": "AAPL", "limit_price": 180.0, "sell_fraction": None}
+
+
+@pytest.mark.asyncio
+async def test_stop_loss_sell_strategy_uses_marketable_signal_price_below_stop_loss(monkeypatch):
+    results = {}
+
+    class FakeUSTrader:
+        def __init__(self, mode):
+            results["mode"] = mode
+
+        async def async_sell_stock(self, ticker, limit_price=None, sell_fraction=None):
+            results["ticker"] = ticker
+            results["limit_price"] = limit_price
+            results["sell_fraction"] = sell_fraction
+            return {"success": True, "message": "triggered-stop-loss-sell"}
+
+    monkeypatch.setattr("trading.strategies.common.USStockTrading", FakeUSTrader)
+    monkeypatch.setattr("trading.dispatch.is_market_open", lambda market: True)
+
+    dispatcher = TradeDispatcher(trading_mode="demo", strategy_config={"name": "stop_loss_sell"})
+    signal = parse_signal_payload({"type": "SELL", "ticker": "AAPL", "market": "US", "price": 175, "stop_loss": 180})
+    result = await dispatcher.dispatch(signal)
+
+    assert result.status == "executed"
+    assert results == {"mode": "demo", "ticker": "AAPL", "limit_price": 175.0, "sell_fraction": None}
 
 
 @pytest.mark.asyncio

--- a/trading/STRATEGIES.md
+++ b/trading/STRATEGIES.md
@@ -54,12 +54,13 @@ When a SELL signal arrives with `stop_loss: 180`, the bot sends the sell order w
 
 - It only handles **SELL** signals.
 - It prefers `stop_loss` over `price` for the sell limit price.
+- For US stop-loss SELL signals where `price` has already moved below `stop_loss`, it uses the lower signal `price` so the KIS limit order is marketable instead of waiting for a recovery.
 - If `stop_loss` is missing and `fallback_to_signal_price` is `true`, it uses the signal `price` instead.
 - If neither usable price exists, it rejects the strategy execution instead of sending an unpriced sell.
 
 ### Main setting
 
-- `fallback_to_signal_price`: whether to use `price` when `stop_loss` is missing.
+- `fallback_to_signal_price`: whether to use `price` when `stop_loss` is missing, or when a US SELL arrives after `price` has already crossed below `stop_loss`.
   - Default: `true`.
 
 ### When it is useful

--- a/trading/STRATEGIES.md
+++ b/trading/STRATEGIES.md
@@ -20,6 +20,7 @@ If `name` is empty, the bot uses the normal old behavior.
 | `score_weighted` | Buy more when the signal score is stronger. | BUY |
 | `risk_bracket` | Decide the buy size by how much money you are willing to risk. | BUY |
 | `profit_ladder` | Sell in steps as profit gets bigger, like climbing a ladder. | SELL |
+| `stop_loss_sell` | Sell at the stop-loss price sent by Pub/Sub. | SELL |
 | `limit_buffer` | Move the limit price a little to help the order price. | BUY and SELL |
 | `cooldown` | Wait before trading the same thing again. | Usually BUY |
 | `event_risk_off` | Remember danger events and block or shrink buys for a while. | EVENT and BUY |
@@ -30,12 +31,40 @@ In `trading/config/kis_devlp.yaml`, set:
 
 ```yaml
 signal_strategy:
-  name: "balance_split"
+  name: "stop_loss_sell"
 ```
 
-Replace `balance_split` with the strategy you want.
+The example config defaults to `stop_loss_sell` so SELL signals use their Pub/Sub `stop_loss` as the limit price. Replace `stop_loss_sell` with another strategy when you want different behavior.
 Each strategy also has its own settings under `signal_strategy`.
 The example config file shows the available setting names, but this guide explains what they mean.
+
+
+## `stop_loss_sell`
+
+### In one sentence
+
+`stop_loss_sell` sells at the stop-loss price included in the incoming Pub/Sub signal.
+
+### Kid-friendly example
+
+You tell the bot, "If this stock falls to 180, sell it there."
+When a SELL signal arrives with `stop_loss: 180`, the bot sends the sell order with 180 as the limit price.
+
+### What it does
+
+- It only handles **SELL** signals.
+- It prefers `stop_loss` over `price` for the sell limit price.
+- If `stop_loss` is missing and `fallback_to_signal_price` is `true`, it uses the signal `price` instead.
+- If neither usable price exists, it rejects the strategy execution instead of sending an unpriced sell.
+
+### Main setting
+
+- `fallback_to_signal_price`: whether to use `price` when `stop_loss` is missing.
+  - Default: `true`.
+
+### When it is useful
+
+Use this when Pub/Sub already calculates a stop-loss price and you want the bot's default SELL behavior to honor that stop-loss.
 
 ## `balance_split`
 

--- a/trading/config/kis_devlp.yaml.example
+++ b/trading/config/kis_devlp.yaml.example
@@ -117,10 +117,10 @@ accounts:
 # 신호 기반 전략 설정
 # 자세한 전략 설명은 trading/STRATEGIES.md 파일을 읽어보세요.
 # - name: "" 기존 동작 유지 (전략 비활성화)
-# - name: "balance_split", "score_weighted", "risk_bracket", "profit_ladder",
-#         "limit_buffer", "cooldown", "event_risk_off" 중 하나를 선택할 수 있습니다.
+# - name: "stop_loss_sell", "balance_split", "score_weighted", "risk_bracket",
+#         "profit_ladder", "limit_buffer", "cooldown", "event_risk_off" 중 하나를 선택할 수 있습니다.
 signal_strategy:
-  name: ""
+  name: "stop_loss_sell"
   split_count: 2
   base_amount_krw: 50000
   base_amount_usd: 100
@@ -141,6 +141,7 @@ signal_strategy:
     20: 1.0
   stop_loss_sell_percent: 1.0
   default_sell_percent: 1.0
+  fallback_to_signal_price: true
   full_exit_reasons:
     - stop_loss
     - risk_off

--- a/trading/dispatch.py
+++ b/trading/dispatch.py
@@ -29,6 +29,8 @@ from .strategies import (
     RiskBracketStrategyConfig,
     ScoreWeightedStrategy,
     ScoreWeightedStrategyConfig,
+    StopLossSellStrategy,
+    StopLossSellStrategyConfig,
 )
 from .us import USStockTrading
 
@@ -71,6 +73,7 @@ class TradeDispatcher:
         self.limit_buffer_config = LimitBufferStrategyConfig.from_mapping(self.strategy_config)
         self.cooldown_config = CooldownStrategyConfig.from_mapping(self.strategy_config)
         self.event_risk_off_config = EventRiskOffStrategyConfig.from_mapping(self.strategy_config)
+        self.stop_loss_sell_config = StopLossSellStrategyConfig.from_mapping(self.strategy_config)
         self.account_name = account_name
         self.account_index = account_index
 
@@ -159,8 +162,11 @@ class TradeDispatcher:
                 return ScoreWeightedStrategy(config=self.score_weighted_config)
             if self.risk_bracket_config is not None:
                 return RiskBracketStrategy(config=self.risk_bracket_config)
-        if signal.signal_type == "SELL" and self.profit_ladder_config is not None:
-            return ProfitLadderStrategy(config=self.profit_ladder_config)
+        if signal.signal_type == "SELL":
+            if self.stop_loss_sell_config is not None:
+                return StopLossSellStrategy(config=self.stop_loss_sell_config)
+            if self.profit_ladder_config is not None:
+                return ProfitLadderStrategy(config=self.profit_ladder_config)
         return None
 
     def _resolve_buy_strategy(self, signal: SignalMessage) -> BalanceSplitStrategy | None:

--- a/trading/strategies/README.md
+++ b/trading/strategies/README.md
@@ -11,6 +11,7 @@ strategy.
 - `score_weighted`: BUY with a configured amount multiplied by the incoming `buy_score` band.
 - `risk_bracket`: BUY from a risk budget derived from `price` and `stop_loss`, with optional bracket metadata persistence.
 - `profit_ladder`: SELL through configured `profit_rate` bands or full-exit reasons.
+- `stop_loss_sell`: SELL at the incoming `stop_loss` price by default, with optional fallback to `price`.
 - `limit_buffer`: BUY/SELL using a buffered limit price around the signal price.
 - `cooldown`: execute a trade only when the same configured ticker/signal key has not traded recently.
 - `event_risk_off`: record risk-off EVENT signals and reject matching BUY signals while the state is fresh.

--- a/trading/strategies/README.md
+++ b/trading/strategies/README.md
@@ -11,7 +11,7 @@ strategy.
 - `score_weighted`: BUY with a configured amount multiplied by the incoming `buy_score` band.
 - `risk_bracket`: BUY from a risk budget derived from `price` and `stop_loss`, with optional bracket metadata persistence.
 - `profit_ladder`: SELL through configured `profit_rate` bands or full-exit reasons.
-- `stop_loss_sell`: SELL at the incoming `stop_loss` price by default, with optional fallback to `price`.
+- `stop_loss_sell`: SELL at the incoming `stop_loss` price by default, using `price` when configured as a fallback or when a triggered US stop-loss sell needs a marketable limit.
 - `limit_buffer`: BUY/SELL using a buffered limit price around the signal price.
 - `cooldown`: execute a trade only when the same configured ticker/signal key has not traded recently.
 - `event_risk_off`: record risk-off EVENT signals and reject matching BUY signals while the state is fresh.

--- a/trading/strategies/__init__.py
+++ b/trading/strategies/__init__.py
@@ -7,6 +7,7 @@ from .limit_buffer import LIMIT_BUFFER, LimitBufferStrategy, LimitBufferStrategy
 from .profit_ladder import PROFIT_LADDER, ProfitLadderStrategy, ProfitLadderStrategyConfig
 from .risk_bracket import RISK_BRACKET, RiskBracketStrategy, RiskBracketStrategyConfig
 from .score_weighted import SCORE_WEIGHTED, ScoreWeightedStrategy, ScoreWeightedStrategyConfig
+from .stop_loss_sell import STOP_LOSS_SELL, StopLossSellStrategy, StopLossSellStrategyConfig
 
 __all__ = [
     "BALANCE_SPLIT",
@@ -30,4 +31,7 @@ __all__ = [
     "SCORE_WEIGHTED",
     "ScoreWeightedStrategy",
     "ScoreWeightedStrategyConfig",
+    "STOP_LOSS_SELL",
+    "StopLossSellStrategy",
+    "StopLossSellStrategyConfig",
 ]

--- a/trading/strategies/stop_loss_sell.py
+++ b/trading/strategies/stop_loss_sell.py
@@ -1,0 +1,63 @@
+"""Stop-loss limit-price SELL strategy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .common import StrategyExecution, execute_order, execution_from_result, strategy_name
+
+STOP_LOSS_SELL = "stop_loss_sell"
+
+
+@dataclass(slots=True)
+class StopLossSellStrategyConfig:
+    """Configuration for selling at the signal stop-loss price."""
+
+    fallback_to_signal_price: bool = True
+
+    @classmethod
+    def from_mapping(cls, payload: dict[str, Any] | None) -> "StopLossSellStrategyConfig | None":
+        if not payload or strategy_name(payload) != STOP_LOSS_SELL:
+            return None
+        return cls(fallback_to_signal_price=bool(payload.get("fallback_to_signal_price", True)))
+
+
+class StopLossSellStrategy:
+    """Sell using ``stop_loss`` as the preferred limit price."""
+
+    def __init__(self, *, config: StopLossSellStrategyConfig):
+        self.config = config
+
+    async def execute(
+        self,
+        signal,
+        *,
+        trading_mode: str,
+        trader_kwargs: dict[str, Any] | None = None,
+    ) -> StrategyExecution:
+        if signal.signal_type != "SELL":
+            return StrategyExecution("rejected", "Stop-loss sell strategy only supports SELL signals", signal.market, signal.ticker)
+
+        limit_price = signal.stop_loss
+        price_source = "stop_loss"
+        if limit_price in (None, 0) and self.config.fallback_to_signal_price:
+            limit_price = signal.price
+            price_source = "price"
+
+        if limit_price in (None, 0):
+            return StrategyExecution("rejected", "Stop-loss sell strategy requires stop_loss", signal.market, signal.ticker)
+
+        result = await execute_order(
+            signal,
+            trading_mode=trading_mode,
+            limit_price=float(limit_price),
+            trader_kwargs=trader_kwargs,
+        )
+        return execution_from_result(
+            signal,
+            result,
+            "Stop-loss sell strategy executed",
+            limit_price=float(limit_price),
+            price_source=price_source,
+        )

--- a/trading/strategies/stop_loss_sell.py
+++ b/trading/strategies/stop_loss_sell.py
@@ -41,7 +41,7 @@ class StopLossSellStrategy:
 
         limit_price = signal.stop_loss
         price_source = "stop_loss"
-        if limit_price in (None, 0) and self.config.fallback_to_signal_price:
+        if self._should_use_signal_price(signal, limit_price):
             limit_price = signal.price
             price_source = "price"
 
@@ -61,3 +61,10 @@ class StopLossSellStrategy:
             limit_price=float(limit_price),
             price_source=price_source,
         )
+
+    def _should_use_signal_price(self, signal, stop_loss: float | None) -> bool:
+        if not self.config.fallback_to_signal_price or signal.price in (None, 0):
+            return False
+        if stop_loss in (None, 0):
+            return True
+        return signal.market == "US" and float(signal.price) < float(stop_loss)


### PR DESCRIPTION
### Motivation
- Make SELL signals honor stop-loss prices computed upstream so the bot by default sells at the Pub/Sub `stop_loss` price rather than using an implicit legacy path.
- Provide a simple, documented strategy to let operators opt out or fall back to the signal `price` when `stop_loss` is not present.

### Description
- Added a new strategy module `trading/strategies/stop_loss_sell.py` implementing `stop_loss_sell` which prefers `stop_loss` as the sell limit and can optionally fall back to `price`.
- Wired the new strategy into the dispatcher by loading `StopLossSellStrategyConfig` and returning `StopLossSellStrategy` for SELL signals before falling back to `profit_ladder` in `trading/dispatch.py`.
- Exported the new symbols from `trading/strategies/__init__.py` and updated documentation in `trading/STRATEGIES.md` and `trading/strategies/README.md` to describe the strategy.
- Made `stop_loss_sell` the example default `signal_strategy.name` and added `fallback_to_signal_price: true` to `trading/config/kis_devlp.yaml.example` and added two dispatcher tests in `tests/test_dispatch.py` for stop-loss routing and fallback.

### Testing
- Ran Python byte-compile on modified files with `python -m py_compile trading/dispatch.py trading/strategies/stop_loss_sell.py trading/strategies/__init__.py tests/test_dispatch.py`, which succeeded.
- Ran `git diff --check` style checks, which reported no issues.
- Attempted `python -m pytest tests/test_dispatch.py tests/test_strategy_suite.py`, but test collection failed due to an environment-level segmentation fault while importing `pandas_market_calendars` (Python 3.14/pandas interaction), preventing full pytest validation of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a478cd89fac83329996726eaa982058)