### PR TITLE
Add optional raw Pub/Sub payload logging

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -135,6 +135,18 @@ python subscriber.py
 
 Before live mode, verify your KIS accounts, App Key/Secret values, Pub/Sub subscription, and service-account permissions.
 
+### Optional raw Pub/Sub payload log
+
+The normal subscriber log records message metadata, validation, dispatch, and acknowledgement events. To keep unparsed Pub/Sub payloads in a separate file for debugging, opt in with either the CLI flag or environment variable:
+
+```bash
+python subscriber.py --raw-pubsub-log-file logs/raw_pubsub.log
+# or
+RAW_PUBSUB_LOG_FILE=logs/raw_pubsub.log python subscriber.py
+```
+
+Raw Pub/Sub logging is disabled by default because payloads may contain sensitive signal metadata. When enabled, each raw payload is written to the separate KST-rotated log file as one JSON object containing the Pub/Sub context, byte count, and UTF-8 decoded payload.
+
 ## Signal message contract
 
 Inbound Pub/Sub messages may use these fields.

--- a/subscriber.py
+++ b/subscriber.py
@@ -108,8 +108,12 @@ def _configure_logging(log_file: str | None, *, level: str = "INFO") -> None:
         root_logger.addHandler(handler)
 
 
-def _configure_raw_pubsub_logging(log_file: str | None, *, level: str = "INFO") -> logging.Logger | None:
-    """Configure the optional isolated logger for unparsed Pub/Sub payloads."""
+def _configure_raw_pubsub_logging(log_file: str | None) -> logging.Logger | None:
+    """Configure the optional isolated logger for unparsed Pub/Sub payloads.
+
+    Raw payload capture is an explicit debugging opt-in, so keep this
+    isolated logger at INFO regardless of the main subscriber log level.
+    """
     if not log_file:
         RAW_PUBSUB_LOGGER.handlers.clear()
         RAW_PUBSUB_LOGGER.propagate = False
@@ -119,9 +123,10 @@ def _configure_raw_pubsub_logging(log_file: str | None, *, level: str = "INFO") 
     log_path.parent.mkdir(parents=True, exist_ok=True)
     handler = _KSTDailyFileHandler(log_path, encoding="utf-8")
     handler.setFormatter(_KSTFormatter("%(asctime)s - %(message)s"))
+    handler.setLevel(logging.INFO)
 
     RAW_PUBSUB_LOGGER.handlers.clear()
-    RAW_PUBSUB_LOGGER.setLevel(_parse_log_level(level))
+    RAW_PUBSUB_LOGGER.setLevel(logging.INFO)
     RAW_PUBSUB_LOGGER.propagate = False
     RAW_PUBSUB_LOGGER.addHandler(handler)
     return RAW_PUBSUB_LOGGER
@@ -280,7 +285,7 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
     try:
         _configure_logging(args.log_file, level=args.log_level)
-        raw_pubsub_logger = _configure_raw_pubsub_logging(args.raw_pubsub_log_file, level=args.log_level)
+        raw_pubsub_logger = _configure_raw_pubsub_logging(args.raw_pubsub_log_file)
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
 

--- a/subscriber.py
+++ b/subscriber.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import datetime
+import json
 import logging
 import logging.handlers
 import os
@@ -25,6 +26,7 @@ ROOT = Path(__file__).parent
 load_dotenv(ROOT / ".env")
 
 LOGGER = logging.getLogger("subscriber")
+RAW_PUBSUB_LOGGER = logging.getLogger("subscriber.raw_pubsub")
 
 
 class _KSTFormatter(logging.Formatter):
@@ -106,6 +108,25 @@ def _configure_logging(log_file: str | None, *, level: str = "INFO") -> None:
         root_logger.addHandler(handler)
 
 
+def _configure_raw_pubsub_logging(log_file: str | None, *, level: str = "INFO") -> logging.Logger | None:
+    """Configure the optional isolated logger for unparsed Pub/Sub payloads."""
+    if not log_file:
+        RAW_PUBSUB_LOGGER.handlers.clear()
+        RAW_PUBSUB_LOGGER.propagate = False
+        return None
+
+    log_path = Path(log_file)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handler = _KSTDailyFileHandler(log_path, encoding="utf-8")
+    handler.setFormatter(_KSTFormatter("%(asctime)s - %(message)s"))
+
+    RAW_PUBSUB_LOGGER.handlers.clear()
+    RAW_PUBSUB_LOGGER.setLevel(_parse_log_level(level))
+    RAW_PUBSUB_LOGGER.propagate = False
+    RAW_PUBSUB_LOGGER.addHandler(handler)
+    return RAW_PUBSUB_LOGGER
+
+
 class QueueWorker:
     def __init__(self, dispatcher: TradeDispatcher, poll_seconds: int):
         self.dispatcher = dispatcher
@@ -149,9 +170,33 @@ def _message_context(message) -> str:
     return " ".join(parts) if parts else "message_id=unknown"
 
 
-def _handle_message(message, dispatcher: TradeDispatcher, logger: logging.Logger | None = None) -> None:
+def _log_raw_pubsub_message(message, context: str, raw_logger: logging.Logger | None) -> None:
+    if raw_logger is None:
+        return
+    raw_data = message.data or b""
+    raw_logger.info(
+        "%s",
+        json.dumps(
+            {
+                "context": context,
+                "bytes": len(raw_data),
+                "payload": raw_data.decode("utf-8", errors="replace"),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+    )
+
+
+def _handle_message(
+    message,
+    dispatcher: TradeDispatcher,
+    logger: logging.Logger | None = None,
+    raw_logger: logging.Logger | None = None,
+) -> None:
     active_logger = logger or LOGGER
     context = _message_context(message)
+    _log_raw_pubsub_message(message, context, raw_logger)
     active_logger.info("Received Pub/Sub message (%s, bytes=%s)", context, len(message.data or b""))
     try:
         signal = parse_signal_bytes(message.data)
@@ -183,8 +228,12 @@ def _handle_message(message, dispatcher: TradeDispatcher, logger: logging.Logger
         active_logger.info("Acknowledged Pub/Sub message (%s)", context)
 
 
-def build_callback(dispatcher: TradeDispatcher, logger: logging.Logger | None = None):
-    return lambda message: _handle_message(message, dispatcher, logger)
+def build_callback(
+    dispatcher: TradeDispatcher,
+    logger: logging.Logger | None = None,
+    raw_logger: logging.Logger | None = None,
+):
+    return lambda message: _handle_message(message, dispatcher, logger, raw_logger)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -193,6 +242,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--subscription-id", default=os.environ.get("GCP_PUBSUB_SUBSCRIPTION_ID"))
     parser.add_argument("--credentials-path", default=os.environ.get("GCP_CREDENTIALS_PATH"))
     parser.add_argument("--log-file", default="logs/subscriber.log")
+    parser.add_argument(
+        "--raw-pubsub-log-file",
+        default=os.environ.get("RAW_PUBSUB_LOG_FILE"),
+        help="Optional separate file for raw Pub/Sub payload logs (disabled by default)",
+    )
     parser.add_argument(
         "--log-level",
         default=os.environ.get("LOG_LEVEL", "INFO"),
@@ -226,6 +280,7 @@ def main(argv: list[str] | None = None) -> None:
     args = parse_args(argv)
     try:
         _configure_logging(args.log_file, level=args.log_level)
+        raw_pubsub_logger = _configure_raw_pubsub_logging(args.raw_pubsub_log_file, level=args.log_level)
     except ValueError as exc:
         raise SystemExit(str(exc)) from exc
 
@@ -258,17 +313,18 @@ def main(argv: list[str] | None = None) -> None:
     subscriber = pubsub_v1.SubscriberClient(credentials=credentials) if credentials else pubsub_v1.SubscriberClient()
     subscription_path = subscriber.subscription_path(args.project_id, args.subscription_id)
     LOGGER.info(
-        "Listening on %s (dry_run=%s, mode=%s, queue_path=%s, queue_poll_seconds=%s)",
+        "Listening on %s (dry_run=%s, mode=%s, queue_path=%s, queue_poll_seconds=%s, raw_pubsub_log=%s)",
         subscription_path,
         args.dry_run,
         dispatcher.trading_mode,
         args.queue_path,
         args.queue_poll_seconds,
+        args.raw_pubsub_log_file or "disabled",
     )
 
     streaming_pull_future = subscriber.subscribe(
         subscription_path,
-        callback=lambda message: _handle_message(message, dispatcher),
+        callback=lambda message: _handle_message(message, dispatcher, raw_logger=raw_pubsub_logger),
     )
     stop_event = threading.Event()
 

--- a/tests/test_subscriber_smoke.py
+++ b/tests/test_subscriber_smoke.py
@@ -83,6 +83,25 @@ def test_parse_args_raw_pubsub_log_file_from_env(monkeypatch):
 
     assert args.raw_pubsub_log_file == "logs/raw_pubsub.log"
 
+
+def test_raw_pubsub_logging_ignores_main_warning_level(tmp_path):
+    dispatcher = FakeDispatcher()
+    message = FakeMessage(b'{"type":"BUY","ticker":"005930","market":"KR","price":82000}')
+    raw_log = tmp_path / "raw_pubsub.log"
+
+    subscriber._configure_logging(None, level="WARNING")
+    raw_logger = subscriber._configure_raw_pubsub_logging(str(raw_log))
+
+    try:
+        subscriber._handle_message(message, dispatcher, raw_logger=raw_logger)
+    finally:
+        subscriber._configure_raw_pubsub_logging(None)
+
+    text = raw_log.read_text(encoding="utf-8")
+    assert '"payload":' in text
+    assert '005930' in text
+
+
 def test_web_ui_flag_still_requires_pubsub_settings(monkeypatch):
     launched = []
 

--- a/tests/test_subscriber_smoke.py
+++ b/tests/test_subscriber_smoke.py
@@ -58,6 +58,31 @@ def test_handle_message_logs_dispatch_message(caplog):
     assert "Acknowledged Pub/Sub message" in caplog.text
 
 
+def test_handle_message_optionally_logs_raw_pubsub_payload(tmp_path):
+    dispatcher = FakeDispatcher()
+    message = FakeMessage(b'{"type":"BUY","ticker":"005930","market":"KR","price":82000}')
+    raw_log = tmp_path / "raw_pubsub.log"
+    raw_logger = subscriber._configure_raw_pubsub_logging(str(raw_log))
+
+    try:
+        subscriber._handle_message(message, dispatcher, raw_logger=raw_logger)
+    finally:
+        subscriber._configure_raw_pubsub_logging(None)
+
+    text = raw_log.read_text(encoding="utf-8")
+    assert '"bytes": 60' in text
+    assert '"context": "message_id=msg-1 delivery_attempt=2"' in text
+    assert '"payload":' in text
+    assert '005930' in text
+
+
+def test_parse_args_raw_pubsub_log_file_from_env(monkeypatch):
+    monkeypatch.setenv("RAW_PUBSUB_LOG_FILE", "logs/raw_pubsub.log")
+
+    args = subscriber.parse_args([])
+
+    assert args.raw_pubsub_log_file == "logs/raw_pubsub.log"
+
 def test_web_ui_flag_still_requires_pubsub_settings(monkeypatch):
     launched = []
 

--- a/webui/services/log_service.py
+++ b/webui/services/log_service.py
@@ -10,6 +10,7 @@ from .masking import mask_text
 
 _ALLOWED_LOGS = {
     "subscriber": Path("logs") / "subscriber.log",
+    "raw_pubsub": Path("logs") / "raw_pubsub.log",
     "runtime": Path("runtime") / "subscriber.log",
 }
 


### PR DESCRIPTION
### Motivation

- Provide an opt-in, isolated logging path for raw Pub/Sub payloads to aid debugging of unparsed or malformed signals without contaminating the main subscriber logs.
- Keep raw payloads separate because they may contain sensitive signal metadata and should be disabled by default.

### Description

- Add a dedicated logger `RAW_PUBSUB_LOGGER` and a helper ` _configure_raw_pubsub_logging` that creates a KST-daily-rotated file handler when a path is provided.
- Capture raw message bytes and decoded payload via `_log_raw_pubsub_message` and wire it into message processing by extending `_handle_message` to accept an optional `raw_logger` and calling it before parsing.
- Add a CLI/env option `--raw-pubsub-log-file` / `RAW_PUBSUB_LOG_FILE` and configure/preserve the `raw_pubsub` state in `main`, then pass the `raw_pubsub_logger` into the subscription callback.
- Expose the default `raw_pubsub` log path in the WebUI allowlist (`webui/services/log_service.py`) and document usage and privacy implications in `README.en.md`.
- Add smoke tests covering raw-payload capture and env-based configuration in `tests/test_subscriber_smoke.py`.

### Testing

- `python -m py_compile subscriber.py` completed successfully.
- `pytest tests/test_subscriber_smoke.py -q` passed (subscriber smoke tests including new raw-pubsub tests).
- `pytest tests/test_webui_log_service.py -q` passed (webui log tail allowlist tests).
- Full test suite `pytest -q` completed successfully with all tests passing (171 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4791fe62048332b47a883ce2e5c611)